### PR TITLE
Alternative default syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+bitbybit/CHANGELOG.md

--- a/bitbybit-tests/tests/bitfield_tests.rs
+++ b/bitbybit-tests/tests/bitfield_tests.rs
@@ -7,7 +7,7 @@ fn test_construction() {
     #[bitfield(u32, default: 0)]
     struct Test2 {}
 
-    let t = Test2::new();
+    let t = Test2::DEFAULT;
     assert_eq!(0, t.raw_value);
 
     let t = Test2::new_with_raw_value(45);
@@ -45,7 +45,7 @@ fn test_getter_and_setter() {
     assert_eq!(0xE0, t.baudrate());
     assert_eq!(u4::new(0x6), t.some_other_bits());
 
-    let t = Test2::new()
+    let t = Test2::DEFAULT
         .with_baudrate(0x12)
         .with_some_other_bits(u4::new(0x2));
     assert_eq!(0x12, t.baudrate());
@@ -68,7 +68,7 @@ fn test_getter_and_setter_arbitrary_uint() {
     assert_eq!(0xE0, t.baudrate());
     assert_eq!(u4::new(0x6), t.some_other_bits());
 
-    let t = Test2::new()
+    let t = Test2::DEFAULT
         .with_baudrate(0x12)
         .with_some_other_bits(u4::new(0x2));
     assert_eq!(0x12, t.baudrate());
@@ -96,7 +96,7 @@ fn test_bool() {
         o: u3,
     }
 
-    let t = Test::new();
+    let t = Test::DEFAULT;
     assert!(!t.bit0());
     assert!(!t.bit1());
     assert_eq!(t.raw_value, 0b00);
@@ -132,7 +132,7 @@ fn test_u1() {
         o: u3,
     }
 
-    let t = Test::new();
+    let t = Test::DEFAULT;
     assert_eq!(t.bit0(), u1::new(0));
     assert_eq!(t.bit1(), u1::new(0));
     assert_eq!(t.raw_value, 0b00);
@@ -184,7 +184,7 @@ fn default_value() {
     #[bitfield(u32, default: 0xDEADBEEF)]
     struct Test {}
 
-    let t = Test::new();
+    let t = Test::DEFAULT;
     assert_eq!(t.raw_value, 0xDEADBEEF);
 }
 
@@ -194,7 +194,7 @@ fn default_value_const() {
     #[bitfield(u32, default: DEFAULT)]
     struct Test {}
 
-    let t = Test::new();
+    let t = Test::DEFAULT;
     assert_eq!(t.raw_value, 0xBADCAFE);
 }
 
@@ -247,7 +247,7 @@ fn proper_unmasking() {
         c: u2,
     }
 
-    let s1 = TestStruct::new()
+    let s1 = TestStruct::DEFAULT
         .with_a(u2::new(0b11))
         .with_b(u2::new(0b11))
         .with_c(u2::new(0b11));
@@ -266,7 +266,7 @@ fn just_one_bitrange() {
         a: i16,
     }
 
-    let s1 = JustOneBitRange::new().with_a(0b0111001110001111);
+    let s1 = JustOneBitRange::DEFAULT.with_a(0b0111001110001111);
 
     assert_eq!(0b0111001110001111, s1.raw_value());
     assert_eq!(0b0111001110001111, s1.a());
@@ -610,13 +610,13 @@ fn bitfield_with_enum_exhaustive() {
 
     assert_eq!(
         0b10,
-        BitfieldWithEnum::new()
+        BitfieldWithEnum::DEFAULT
             .with_e1(ExhaustiveEnum::Two)
             .raw_value()
     );
     assert_eq!(
         0b11,
-        BitfieldWithEnum::new()
+        BitfieldWithEnum::DEFAULT
             .with_e1(ExhaustiveEnum::Three)
             .raw_value()
     );
@@ -657,19 +657,19 @@ fn bitfield_with_enum_nonexhaustive() {
 
     assert_eq!(
         0b0000,
-        BitfieldWithEnumNonExhaustive::new()
+        BitfieldWithEnumNonExhaustive::DEFAULT
             .with_e2(NonExhaustiveEnum::Zero)
             .raw_value()
     );
     assert_eq!(
         0b0100,
-        BitfieldWithEnumNonExhaustive::new()
+        BitfieldWithEnumNonExhaustive::DEFAULT
             .with_e2(NonExhaustiveEnum::One)
             .raw_value()
     );
     assert_eq!(
         0b1000,
-        BitfieldWithEnumNonExhaustive::new()
+        BitfieldWithEnumNonExhaustive::DEFAULT
             .with_e2(NonExhaustiveEnum::Two)
             .raw_value()
     );
@@ -859,6 +859,17 @@ fn default_value_automatically_implements_default() {
 
     // If this compiles then derive(Debug) worked
     let a = Test::default();
-    let b = Test::new();
+    let b = Test::DEFAULT;
     assert_eq!(a, b);
+}
+
+#[test]
+fn new_can_still_be_called() {
+    #[bitfield(u32, default: 567)]
+    #[derive(Eq, PartialEq, Debug)]
+    struct Test {}
+
+    #[allow(deprecated)]
+    let old_new = Test::new();
+    assert_eq!(old_new.raw_value(), 567);
 }

--- a/bitbybit/CHANGELOG.md
+++ b/bitbybit/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## bitbybit 1.2.0
+
+### Added
+
+### Changed
+
+- `new()` has caused some confusion - it's a harmless way to create a default. In practice, this wasn't really clear and people thought the function might read e.g. from hardware. `new()` is now deprecated. `default()` (or `DEFAULT` in const contexts) take its place.
+
+### Fixed

--- a/bitbybit/Cargo.toml
+++ b/bitbybit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitbybit"
-version = "1.1.5"
+version = "1.2.0"
 authors = ["Daniel Lehmann <danlehmannmuc@gmail.com>"]
 edition = "2021"
 description = "Efficient implementation of bit-fields where several numbers are packed within a larger number and bit-enums. Useful for drivers, so it works in no_std environments"

--- a/bitbybit/README.md
+++ b/bitbybit/README.md
@@ -123,6 +123,33 @@ struct NibbleBits64 {
 }
 ```
 
+## Default
+
+Bitfields can always be created through new_with_raw_value():
+
+```rs
+let a = NibbleBits64::new_with_raw_value(0x43218765);
+```
+
+However, pretty often a specific value can be considered the default (for example 0). This can be specified like this:
+
+```rs
+#[bitfield(u32, default: 0x1234)]
+struct Bitfield1 {
+  #[bits(0..=3, rw)]
+  nibble: [u4; 4],
+}
+```
+
+If a default value is specified, the bitfield can easily be created with this specific value:
+
+```rs
+let a = Bitfield1::Default;
+const A: Bitfield1 = Bitfield1::DEFAULT;
+```
+
+Default values are used as-is, even if they affect bits that aren't defined within the bitfield.
+
 ## Dependencies
 
 Arbitrary bit widths like u5 or u67 do not exist in Rust at the moment. Therefore, the following dependency is required:
@@ -143,5 +170,5 @@ let a = NibbleBits64::new_with_raw_value(0x12345678_ABCDEFFF);
 assert_eq!(u4::new(0xE), a.nibble(3));
 // Change a value
 let b = a.with_nibble(0, u4::new(0x3))
-assert_eq!(0x12345678_ABCDEFF3, nibble.raw_value());
+assert_eq!(0x12345678_ABCDEFF3, b.raw_value());
 ```

--- a/bitbybit/src/bitfield.rs
+++ b/bitbybit/src/bitfield.rs
@@ -534,18 +534,18 @@ pub fn bitfield(args: TokenStream, input: TokenStream) -> TokenStream {
 
     let (default_constructor, default_trait) = if let Some(default_value) = default_value {
         (
-            quote! {
-                /// An instance that uses the default value.
-                ///
-                /// For example, the following definition would create an instance with a
-                /// raw_value of 0x123:
-                /// #[bitfield(u32, default: 0x123)]
-                #[inline]
-                pub const DEFAULT: Self = Self { raw_value: #default_value };
+            {
+                let comment = format!("An instance that uses the default value {}", default_value);
+                let deprecated_warning = format!("Use {}::Default (or {}::DEFAULT in const context) instead", struct_name, struct_name);
+                quote! {
+                    #[doc = #comment]
+                    #[inline]
+                    pub const DEFAULT: Self = Self { raw_value: #default_value };
 
-                #[deprecated(note = "Use DEFAULT instead of new()")]
-                pub const fn new() -> Self {
-                    Self::DEFAULT
+                    #[deprecated(note = #deprecated_warning)]
+                    pub const fn new() -> Self {
+                        Self::DEFAULT
+                    }
                 }
             },
             quote! {

--- a/bitbybit/src/bitfield.rs
+++ b/bitbybit/src/bitfield.rs
@@ -535,18 +535,23 @@ pub fn bitfield(args: TokenStream, input: TokenStream) -> TokenStream {
     let (default_constructor, default_trait) = if let Some(default_value) = default_value {
         (
             quote! {
-                /// Creates a new instance with the default value.
+                /// An instance that uses the default value.
                 ///
                 /// For example, the following definition would create an instance with a
                 /// raw_value of 0x123:
                 /// #[bitfield(u32, default: 0x123)]
                 #[inline]
-                pub const fn new() -> #struct_name { #struct_name { raw_value: #default_value } }
+                pub const DEFAULT: Self = Self { raw_value: #default_value };
+
+                #[deprecated(note = "Use DEFAULT instead of new()")]
+                pub const fn new() -> Self {
+                    Self::DEFAULT
+                }
             },
             quote! {
                 impl Default for #struct_name {
                     fn default() -> Self {
-                        Self::new()
+                        Self::DEFAULT
                     }
                 }
             },


### PR DESCRIPTION
`new()` has caused some confusion - it's a harmless looking way to create a default. However, rarely anyone figured out that `new()` is tied to the Default:xxx value specified.

`new()` is now deprecated. `default()` (and the new `DEFAULT` for const contexts) take its place.