### PR TITLE
Make bitenum's non-exhaustive Result type return the proper type

### DIFF
--- a/bitbybit-tests/tests/bitenum_tests.rs
+++ b/bitbybit-tests/tests/bitenum_tests.rs
@@ -34,7 +34,7 @@ fn bitrange_with_enum_type_nonexhaustive_2() {
     assert_eq!(Foo::new_with_raw_value(u2::new(0)), Ok(Foo::Zero));
     assert_eq!(Foo::new_with_raw_value(u2::new(1)), Ok(Foo::One));
     assert_eq!(Foo::new_with_raw_value(u2::new(2)), Ok(Foo::Two));
-    assert_eq!(Foo::new_with_raw_value(u2::new(3)), Err(3));
+    assert_eq!(Foo::new_with_raw_value(u2::new(3)), Err(u2::new(3)));
 
     assert_eq!(Foo::Zero.raw_value(), u2::new(0));
     assert_eq!(Foo::One.raw_value(), u2::new(1));
@@ -143,8 +143,8 @@ fn enum_with_63bits() {
     );
     assert_eq!(Foo::new_with_raw_value(u63::new(2)).unwrap(), Foo::Two);
     assert_eq!(Foo::new_with_raw_value(u63::new(3)).unwrap(), Foo::Three);
-    assert_eq!(Foo::new_with_raw_value(u63::new(4)), Err(4));
-    assert_eq!(Foo::new_with_raw_value(u63::new(255)), Err(255));
+    assert_eq!(Foo::new_with_raw_value(u63::new(4)), Err(u63::new(4)));
+    assert_eq!(Foo::new_with_raw_value(u63::new(255)), Err(u63::new(255)));
 
     assert_eq!(Foo::Zero.raw_value(), u63::new(0));
     assert_eq!(Foo::One.raw_value(), u63::new(0x7FFF_FFFF_FFFF_FFFF));
@@ -236,10 +236,10 @@ fn cfg_in_enum_values() {
     #[cfg(feature = "test123")]
     assert_eq!(Foo::new_with_raw_value(u2::new(2)), Ok(Foo::Test123));
     #[cfg(not(feature = "test123"))]
-    assert_eq!(Foo::new_with_raw_value(u2::new(2)), Err(2));
+    assert_eq!(Foo::new_with_raw_value(u2::new(2)), Err(u2::new(2)));
 
     #[cfg(not(feature = "test123"))]
     assert_eq!(Foo::new_with_raw_value(u2::new(3)), Ok(Foo::TestNot123));
     #[cfg(feature = "test123")]
-    assert_eq!(Foo::new_with_raw_value(u2::new(3)), Err(3));
+    assert_eq!(Foo::new_with_raw_value(u2::new(3)), Err(u2::new(3)));
 }

--- a/bitbybit-tests/tests/bitfield_tests.rs
+++ b/bitbybit-tests/tests/bitfield_tests.rs
@@ -740,7 +740,7 @@ fn bitfield_with_enum_nonexhaustive() {
         BitfieldWithEnumNonExhaustive::new_with_raw_value(0b1010).e2()
     );
     assert_eq!(
-        Err(3),
+        Err(u2::new(3)),
         BitfieldWithEnumNonExhaustive::new_with_raw_value(0b1110).e2()
     );
 
@@ -1246,4 +1246,22 @@ fn underlying_type_is_arbitrary_default() {
             .raw_value(),
         u14::new(0x569)
     );
+}
+
+#[test]
+fn bitenum_without_import() {
+    // Pick an integer that is not currently used. This is to ensure that everything is fully qualified
+    #[bitenum(u41, exhaustive: false)]
+    #[derive(Eq, PartialEq, Debug)]
+    pub enum NonExhaustiveEnum {
+        Zero = 0b00,
+        One = 0b01,
+        Two = 0b10,
+    }
+
+    #[bitfield(u64, default: 0)]
+    pub struct BitfieldWithEnumNonExhaustive {
+        #[bits(0..=40, rw)]
+        e2: Option<NonExhaustiveEnum>,
+    }
 }

--- a/bitbybit/CHANGELOG.md
+++ b/bitbybit/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## bitbybit 1.3.0 (breaking change)
+
+### Added
+
+### Changed
+
+- bitenum's new_with_raw_value, when used with an arbitrary-int type used to return the next larger whole primitive integer, which is unexpected. Slight change, but possibility for breakage:
+```rs
+// Old type
+let foo: Result<MyEnum, u8> = MyEnum::new_with_raw_value(u2::new(0b10));
+
+// New type (notice the u2 instead of u8)
+let foo: Result<MyEnum, u2> = MyEnum::new_with_raw_value(u2::new(0b10));
+```
+
+
+### Fixed
+
 ## bitbybit 1.2.2
 
 ### Added

--- a/bitbybit/src/bitenum.rs
+++ b/bitbybit/src/bitenum.rs
@@ -262,10 +262,10 @@ pub fn bitenum(args: TokenStream, input: TokenStream) -> TokenStream {
         quote!(
             /// Creates a new instance of this bitfield with the given raw value, or
             /// Err(value) if the value does not exist in the enum.
-            pub const fn new_with_raw_value(value: #bounded_data_type) -> Result<Self, #base_data_type> {
+            pub const fn new_with_raw_value(value: #bounded_data_type) -> Result<Self, #bounded_data_type> {
                 match value #bounded_getter {
                     #( #case_values )*
-                    _ => Err(value #bounded_getter)
+                    _ => Err(value)
                 }
             }
         )

--- a/bitbybit/src/bitfield.rs
+++ b/bitbybit/src/bitfield.rs
@@ -1028,10 +1028,21 @@ fn parse_field(base_data_size: usize, field: &Field) -> Result<FieldDefinition, 
                         let option_generic_type = args.args.first().unwrap();
                         match option_generic_type {
                             GenericArgument::Type(generic_type) => {
+                                let enum_fallback_value = {
+                                    let type_string = if is_int_size_regular_type(number_of_bits) {
+                                        format!("u{}", number_of_bits)
+                                    } else {
+                                        format!("arbitrary_int::u{}", number_of_bits)
+                                    };
+                                    syn::parse_str::<Type>(type_string.as_str()).unwrap_or_else(
+                                        |_| panic!("bitfield!: Error parsing unsigned_field_type"),
+                                    )
+                                };
+
                                 let result_type_string = format!(
                                     "Result<{}, {}>",
                                     generic_type.to_token_stream(),
-                                    primitive_type.to_token_stream(),
+                                    enum_fallback_value.to_token_stream(),
                                 );
                                 let result_type = syn::parse_str::<Type>(&result_type_string)
                                     .expect("bitfield!: Error creating type from Result<,>");


### PR DESCRIPTION
This used to be the next largest primitive, which is pretty out of the place compared to the rest of the crate