### PR TITLE
Switch attribute arguments from field syntax (:) to assignment

### DIFF
--- a/bitbybit-tests/tests/bitenum_legacy_tests.rs
+++ b/bitbybit-tests/tests/bitenum_legacy_tests.rs
@@ -3,7 +3,7 @@ use bitbybit::bitenum;
 
 #[test]
 fn bitrange_with_enum_type_exhaustive_2() {
-    #[bitenum(u2, exhaustive = true)]
+    #[bitenum(u2, exhaustive: true)]
     #[derive(Eq, PartialEq, Debug)]
     enum Foo {
         Zero = 0b00,
@@ -23,7 +23,7 @@ fn bitrange_with_enum_type_exhaustive_2() {
 
 #[test]
 fn bitrange_with_enum_type_nonexhaustive_2() {
-    #[bitenum(u2, exhaustive = false)]
+    #[bitenum(u2, exhaustive: false)]
     #[derive(Eq, PartialEq, Debug)]
     enum Foo {
         Zero = 0b00,
@@ -43,7 +43,7 @@ fn bitrange_with_enum_type_nonexhaustive_2() {
 
 #[test]
 fn enum_without_other_derives() {
-    #[bitenum(u2, exhaustive = true)]
+    #[bitenum(u2, exhaustive: true)]
     enum Foo {
         Zero = 0,
         One = 1,
@@ -60,7 +60,7 @@ fn enum_without_other_derives() {
 
 #[test]
 fn enum_with_8bits() {
-    #[bitenum(u8, exhaustive = false)]
+    #[bitenum(u8, exhaustive: false)]
     #[derive(Eq, PartialEq, Debug)]
     enum Foo {
         Zero = 0,
@@ -82,7 +82,7 @@ fn enum_with_8bits() {
 
 #[test]
 fn enum_with_16bits() {
-    #[bitenum(u16, exhaustive = false)]
+    #[bitenum(u16, exhaustive: false)]
     #[derive(Eq, PartialEq, Debug)]
     enum Foo {
         Zero = 0,
@@ -104,7 +104,7 @@ fn enum_with_16bits() {
 
 #[test]
 fn enum_with_32bits() {
-    #[bitenum(u32, exhaustive = false)]
+    #[bitenum(u32, exhaustive: false)]
     #[derive(Eq, PartialEq, Debug)]
     enum Foo {
         Zero = 0,
@@ -126,7 +126,7 @@ fn enum_with_32bits() {
 
 #[test]
 fn enum_with_63bits() {
-    #[bitenum(u63, exhaustive = false)]
+    #[bitenum(u63, exhaustive: false)]
     #[derive(Eq, PartialEq, Debug)]
     #[repr(u64)]
     enum Foo {
@@ -152,7 +152,7 @@ fn enum_with_63bits() {
 
 #[test]
 fn enum_with_64bits() {
-    #[bitenum(u64, exhaustive = false)]
+    #[bitenum(u64, exhaustive: false)]
     #[derive(Eq, PartialEq, Debug)]
     #[repr(u64)]
     enum Foo {
@@ -179,7 +179,7 @@ fn enum_with_64bits() {
 #[test]
 fn documentation() {
     /// This is a comment for the whole enum
-    #[bitenum(u2, exhaustive = true)]
+    #[bitenum(u2, exhaustive: true)]
     #[derive(Eq, PartialEq, Debug)]
     enum Foo {
         /// Zero is the absence of stuff
@@ -202,11 +202,11 @@ fn documentation() {
 
 /// Ensures that conditional statements in enum values are handled correctly
 /// (i.e. they don't result in a compile error). We need to specify the new
-/// mode exhaustive = conditional to ensure that the macro doesn't actually check
+/// mode exhaustive: conditional to ensure that the macro doesn't actually check
 /// and simply treats it like a non-exhaustive enum.
 #[test]
 fn cfg_in_enum_values() {
-    #[bitenum(u2, exhaustive = conditional)]
+    #[bitenum(u2, exhaustive: conditional)]
     #[derive(Eq, PartialEq, Debug)]
     enum Foo {
         /// Zero is the absence of stuff

--- a/bitbybit-tests/tests/bitenum_tests.rs
+++ b/bitbybit-tests/tests/bitenum_tests.rs
@@ -3,6 +3,26 @@ use bitbybit::bitenum;
 
 #[test]
 fn bitrange_with_enum_type_exhaustive_2() {
+    #[bitenum(u2, exhaustive = true)]
+    #[derive(Eq, PartialEq, Debug)]
+    enum Foo {
+        Zero = 0b00,
+        One = 0b01,
+        Two = 0b10,
+        Three = 0b11,
+    }
+
+    assert_eq!(Foo::new_with_raw_value(u2::new(0)), Foo::Zero);
+    assert_eq!(Foo::new_with_raw_value(u2::new(1)), Foo::One);
+    assert_eq!(Foo::new_with_raw_value(u2::new(2)), Foo::Two);
+    assert_eq!(Foo::new_with_raw_value(u2::new(3)), Foo::Three);
+
+    assert_eq!(Foo::Zero.raw_value(), u2::new(0));
+    assert_eq!(Foo::One.raw_value(), u2::new(1));
+}
+
+#[test]
+fn bitrange_with_enum_type_exhaustive_2_old_syntax() {
     #[bitenum(u2, exhaustive: true)]
     #[derive(Eq, PartialEq, Debug)]
     enum Foo {
@@ -23,7 +43,7 @@ fn bitrange_with_enum_type_exhaustive_2() {
 
 #[test]
 fn bitrange_with_enum_type_nonexhaustive_2() {
-    #[bitenum(u2, exhaustive: false)]
+    #[bitenum(u2, exhaustive = false)]
     #[derive(Eq, PartialEq, Debug)]
     enum Foo {
         Zero = 0b00,
@@ -43,7 +63,7 @@ fn bitrange_with_enum_type_nonexhaustive_2() {
 
 #[test]
 fn enum_without_other_derives() {
-    #[bitenum(u2, exhaustive: true)]
+    #[bitenum(u2, exhaustive = true)]
     enum Foo {
         Zero = 0,
         One = 1,
@@ -60,7 +80,7 @@ fn enum_without_other_derives() {
 
 #[test]
 fn enum_with_8bits() {
-    #[bitenum(u8, exhaustive: false)]
+    #[bitenum(u8, exhaustive = false)]
     #[derive(Eq, PartialEq, Debug)]
     enum Foo {
         Zero = 0,
@@ -82,7 +102,7 @@ fn enum_with_8bits() {
 
 #[test]
 fn enum_with_16bits() {
-    #[bitenum(u16, exhaustive: false)]
+    #[bitenum(u16, exhaustive = false)]
     #[derive(Eq, PartialEq, Debug)]
     enum Foo {
         Zero = 0,
@@ -104,7 +124,7 @@ fn enum_with_16bits() {
 
 #[test]
 fn enum_with_32bits() {
-    #[bitenum(u32, exhaustive: false)]
+    #[bitenum(u32, exhaustive = false)]
     #[derive(Eq, PartialEq, Debug)]
     enum Foo {
         Zero = 0,
@@ -126,7 +146,7 @@ fn enum_with_32bits() {
 
 #[test]
 fn enum_with_63bits() {
-    #[bitenum(u63, exhaustive: false)]
+    #[bitenum(u63, exhaustive = false)]
     #[derive(Eq, PartialEq, Debug)]
     #[repr(u64)]
     enum Foo {
@@ -152,7 +172,7 @@ fn enum_with_63bits() {
 
 #[test]
 fn enum_with_64bits() {
-    #[bitenum(u64, exhaustive: false)]
+    #[bitenum(u64, exhaustive = false)]
     #[derive(Eq, PartialEq, Debug)]
     #[repr(u64)]
     enum Foo {
@@ -179,7 +199,7 @@ fn enum_with_64bits() {
 #[test]
 fn documentation() {
     /// This is a comment for the whole enum
-    #[bitenum(u2, exhaustive: true)]
+    #[bitenum(u2, exhaustive = true)]
     #[derive(Eq, PartialEq, Debug)]
     enum Foo {
         /// Zero is the absence of stuff
@@ -202,11 +222,11 @@ fn documentation() {
 
 /// Ensures that conditional statements in enum values are handled correctly
 /// (i.e. they don't result in a compile error). We need to specify the new
-/// mode exhaustive: conditional to ensure that the macro doesn't actually check
+/// mode exhaustive = conditional to ensure that the macro doesn't actually check
 /// and simply treats it like a non-exhaustive enum.
 #[test]
 fn cfg_in_enum_values() {
-    #[bitenum(u2, exhaustive: conditional)]
+    #[bitenum(u2, exhaustive = conditional)]
     #[derive(Eq, PartialEq, Debug)]
     enum Foo {
         /// Zero is the absence of stuff

--- a/bitbybit-tests/tests/bitfield_tests.rs
+++ b/bitbybit-tests/tests/bitfield_tests.rs
@@ -4,7 +4,7 @@ use bitbybit::bitfield;
 
 #[test]
 fn test_construction() {
-    #[bitfield(u32, default: 0)]
+    #[bitfield(u32, default = 0)]
     struct Test2 {}
 
     let t = Test2::DEFAULT;
@@ -16,7 +16,7 @@ fn test_construction() {
 
 #[test]
 fn test_getter_and_setter() {
-    #[bitfield(u128, default: 0)]
+    #[bitfield(u128, default = 0)]
     struct Test2 {
         #[bits(98..=127, rw)]
         val30: u30,
@@ -55,7 +55,7 @@ fn test_getter_and_setter() {
 
 #[test]
 fn test_getter_and_setter_arbitrary_uint() {
-    #[bitfield(u128, default: 0)]
+    #[bitfield(u128, default = 0)]
     struct Test2 {
         #[bits(4..=11, rw)]
         baudrate: u8,
@@ -78,7 +78,7 @@ fn test_getter_and_setter_arbitrary_uint() {
 
 #[test]
 fn test_bool() {
-    #[bitfield(u16, default: 0)]
+    #[bitfield(u16, default = 0)]
     struct Test {
         #[bit(0, rw)]
         bit0: bool,
@@ -114,7 +114,7 @@ fn test_bool() {
 
 #[test]
 fn test_u1() {
-    #[bitfield(u16, default: 0)]
+    #[bitfield(u16, default = 0)]
     struct Test {
         #[bit(0, rw)]
         bit0: u1,
@@ -205,7 +205,7 @@ fn signed_masking8and16() {
 
 #[test]
 fn signed_masking32and64() {
-    #[bitfield(u128, default: 0)]
+    #[bitfield(u128, default = 0)]
     struct Test {
         #[bits(32..=95, rw)]
         signed1: i64,
@@ -224,7 +224,7 @@ fn signed_masking32and64() {
 
 #[test]
 fn signed_masking128() {
-    #[bitfield(u128, default: 0)]
+    #[bitfield(u128, default = 0)]
     struct Test {
         #[bits(0..=127, rw)]
         signed0: i128,
@@ -236,7 +236,7 @@ fn signed_masking128() {
 
 #[test]
 fn signed_masking_array() {
-    #[bitfield(u128, default: 0)]
+    #[bitfield(u128, default = 0)]
     struct Test {
         #[bits(96..=127, rw)]
         signed3: i32,
@@ -267,7 +267,7 @@ fn signed_masking_array() {
 
 #[test]
 fn default_value() {
-    #[bitfield(u32, default: 0xDEADBEEF)]
+    #[bitfield(u32, default = 0xDEADBEEF)]
     struct Test {}
 
     let t = Test::DEFAULT;
@@ -277,7 +277,7 @@ fn default_value() {
 #[test]
 fn default_value_const() {
     const DEFAULT: u32 = 0xBADCAFE;
-    #[bitfield(u32, default: DEFAULT)]
+    #[bitfield(u32, default = DEFAULT)]
     struct Test {}
 
     let t = Test::DEFAULT;
@@ -298,7 +298,7 @@ fn more_struct_attributes() {
 #[test]
 fn documentation() {
     /// Test that documentation is properly applied to the output
-    #[bitfield(u32, default: 0x123)]
+    #[bitfield(u32, default = 0x123)]
     #[derive(Debug)]
     struct Test {
         /// This is a documented field
@@ -324,7 +324,7 @@ fn documentation() {
 
 #[test]
 fn proper_unmasking() {
-    #[bitfield(u16, default: 0)]
+    #[bitfield(u16, default = 0)]
     pub struct TestStruct {
         #[bits(0..=1, rw)]
         a: u2,
@@ -349,7 +349,7 @@ fn proper_unmasking() {
 
 #[test]
 fn just_one_bitrange() {
-    #[bitfield(u16, default: 0)]
+    #[bitfield(u16, default = 0)]
     pub struct JustOneBitRange {
         #[bits(0..=15, rw)]
         a: i16,
@@ -363,15 +363,15 @@ fn just_one_bitrange() {
 
 #[test]
 fn repeated_bitrange_single_bits_with_stride() {
-    #[bitfield(u64, default: 0)]
+    #[bitfield(u64, default = 0)]
     pub struct NibbleBits64 {
-        #[bit(0, rw, stride: 4)]
+        #[bit(0, rw, stride = 4)]
         nibble_bit0: [bool; 16],
 
-        #[bit(1, rw, stride: 4)]
+        #[bit(1, rw, stride = 4)]
         nibble_bit1: [bool; 16],
 
-        #[bit(2, rw, stride: 4)]
+        #[bit(2, rw, stride = 4)]
         nibble_bit2: [bool; 16],
 
         #[bit(3, rw, stride: 4)]
@@ -437,18 +437,18 @@ fn repeated_bitrange_single_bits_with_stride() {
 
 #[test]
 fn repeated_bitrange_single_u1_bits_with_stride() {
-    #[bitfield(u64, default: 0)]
+    #[bitfield(u64, default = 0)]
     pub struct NibbleBits64 {
-        #[bit(0, rw, stride: 4)]
+        #[bit(0, rw, stride = 4)]
         nibble_bit0: [u1; 16],
 
-        #[bit(1, rw, stride: 4)]
+        #[bit(1, rw, stride = 4)]
         nibble_bit1: [u1; 16],
 
-        #[bit(2, rw, stride: 4)]
+        #[bit(2, rw, stride = 4)]
         nibble_bit2: [u1; 16],
 
-        #[bit(3, rw, stride: 4)]
+        #[bit(3, rw, stride = 4)]
         nibble_bit3: [u1; 16],
     }
 
@@ -511,7 +511,7 @@ fn repeated_bitrange_single_u1_bits_with_stride() {
 
 #[test]
 fn repeated_bitrange_single_bits_without_stride() {
-    #[bitfield(u8, default: 0)]
+    #[bitfield(u8, default = 0)]
     pub struct Bits8 {
         #[bit(0, rw)]
         bit: [bool; 8],
@@ -534,7 +534,7 @@ fn repeated_bitrange_single_bits_without_stride() {
 
 #[test]
 fn repeated_bitrange_single_u1_bits_without_stride() {
-    #[bitfield(u8, default: 0)]
+    #[bitfield(u8, default = 0)]
     pub struct Bits8 {
         #[bit(0, rw)]
         bit: [u1; 8],
@@ -557,7 +557,7 @@ fn repeated_bitrange_single_u1_bits_without_stride() {
 
 #[test]
 fn repeated_bitrange_without_stride() {
-    #[bitfield(u64, default: 0)]
+    #[bitfield(u64, default = 0)]
     pub struct Nibble64 {
         #[bits(0..=3, rw)]
         nibble: [u4; 16],
@@ -593,9 +593,9 @@ fn repeated_bitrange_without_stride() {
 
 #[test]
 fn repeated_bitrange_with_stride_equals_width() {
-    #[bitfield(u64, default: 0)]
+    #[bitfield(u64, default = 0)]
     pub struct Nibble64 {
-        #[bits(0..=3, rw, stride: 4)]
+        #[bits(0..=3, rw, stride = 4)]
         nibble: [u4; 16],
     }
 
@@ -629,9 +629,9 @@ fn repeated_bitrange_with_stride_equals_width() {
 
 #[test]
 fn repeated_bitrange_with_stride_greater_than_width() {
-    #[bitfield(u64, default: 0)]
+    #[bitfield(u64, default = 0)]
     pub struct EvenNibble64 {
-        #[bits(0..=3, rw, stride: 8)]
+        #[bits(0..=3, rw, stride = 8)]
         even_nibble: [u4; 8],
     }
 
@@ -648,9 +648,9 @@ fn repeated_bitrange_with_stride_greater_than_width() {
 
 #[test]
 fn repeated_bitrange_with_stride_greater_than_width_basic_type() {
-    #[bitfield(u64, default: 0)]
+    #[bitfield(u64, default = 0)]
     pub struct EvenByte64 {
-        #[bits(0..=7, rw, stride: 16)]
+        #[bits(0..=7, rw, stride = 16)]
         even_byte: [u8; 4],
     }
 
@@ -674,7 +674,7 @@ fn bitfield_with_enum_exhaustive() {
         Three = 0b11,
     }
 
-    #[bitfield(u64, default: 0)]
+    #[bitfield(u64, default = 0)]
     pub struct BitfieldWithEnum {
         #[bits(0..=1, rw)]
         e1: ExhaustiveEnum,
@@ -721,7 +721,7 @@ fn bitfield_with_enum_nonexhaustive() {
         Two = 0b10,
     }
 
-    #[bitfield(u64, default: 0)]
+    #[bitfield(u64, default = 0)]
     pub struct BitfieldWithEnumNonExhaustive {
         #[bits(2..=3, rw)]
         e2: Option<NonExhaustiveEnum>,
@@ -777,7 +777,7 @@ fn bitfield_with_indexed_exhaustive_enum() {
         Three = 0b11,
     }
 
-    #[bitfield(u64, default: 0)]
+    #[bitfield(u64, default = 0)]
     pub struct BitfieldWithIndexedEnums {
         #[bits(0..=1, rw)]
         exhaustive: [ExhaustiveEnum; 8],
@@ -814,7 +814,7 @@ fn bitfield_with_indexed_nonexhaustive_enum() {
         Two = 0b10,
     }
 
-    #[bitfield(u64, default: 0)]
+    #[bitfield(u64, default = 0)]
     pub struct BitfieldWithIndexedEnums {
         #[bits(0..=1, rw)]
         nonexhaustive: [Option<NonExhaustiveEnum>; 8],
@@ -851,7 +851,7 @@ fn bitfield_with_u8_enum() {
         Two = 0b10000010,
     }
 
-    #[bitfield(u64, default: 0)]
+    #[bitfield(u64, default = 0)]
     pub struct BitfieldWithIndexedEnums {
         #[bits(6..=13, rw)]
         val8: Option<NonExhaustiveEnum>,
@@ -885,7 +885,7 @@ fn bitfield_with_singlebit_enum() {
         Correct = 1,
     }
 
-    #[bitfield(u32, default: 0)]
+    #[bitfield(u32, default = 0)]
     struct BitfieldWithBitEnum {
         #[bit(6, rw)]
         bit: BitEnum,
@@ -942,7 +942,7 @@ fn with_derive_default() {
 fn default_value_automatically_implements_default() {
     // Early versions didn't automatically implement Default - ensure that this still compiles
     // (though we emit a compiler warning)
-    #[bitfield(u32, default: 2)]
+    #[bitfield(u32, default = 2)]
     #[derive(Eq, PartialEq, Debug)]
     struct Test {}
 
@@ -954,7 +954,7 @@ fn default_value_automatically_implements_default() {
 
 #[test]
 fn new_can_still_be_called() {
-    #[bitfield(u32, default: 567)]
+    #[bitfield(u32, default = 567)]
     #[derive(Eq, PartialEq, Debug)]
     struct Test {}
 
@@ -966,7 +966,7 @@ fn new_can_still_be_called() {
 #[test]
 #[should_panic]
 fn array_out_of_bounds_read() {
-    #[bitfield(u64, default: 0)]
+    #[bitfield(u64, default = 0)]
     pub struct OutOfBoundsTests {
         #[bit(0, rw, stride: 4)]
         nibble_bit0: [u1; 15],
@@ -979,7 +979,7 @@ fn array_out_of_bounds_read() {
 #[test]
 #[should_panic]
 fn array_out_of_bounds_write() {
-    #[bitfield(u64, default: 0)]
+    #[bitfield(u64, default = 0)]
     pub struct OutOfBoundsTests {
         #[bit(0, rw, stride: 4)]
         nibble_bit0: [u1; 15],
@@ -999,7 +999,7 @@ fn reserved_identifiers() {
         r#enum = 1,
     }
 
-    #[bitfield(u32, default: 0)]
+    #[bitfield(u32, default = 0)]
     #[derive(PartialEq, Eq, Debug)]
     struct BitfieldWithBitEnum {
         #[bit(6, rw)]
@@ -1025,7 +1025,7 @@ fn reserved_identifiers() {
 
 #[test]
 fn new_with_construction1() {
-    #[bitfield(u128, default: 0)]
+    #[bitfield(u128, default = 0)]
     struct Test2 {
         #[bits(98..=127, rw)]
         val30: u30,
@@ -1061,7 +1061,7 @@ fn new_with_construction1() {
 
 #[test]
 fn new_with_construction2() {
-    #[bitfield(u128, default: 0)]
+    #[bitfield(u128, default = 0)]
     struct Test2 {
         #[bits(0..=127, rw)]
         val128: u128,
@@ -1075,7 +1075,7 @@ fn new_with_construction2() {
 
 #[test]
 fn new_with_construction3() {
-    #[bitfield(u64, default: 0)]
+    #[bitfield(u64, default = 0)]
     struct Test2 {
         #[bits(0..=63, rw)]
         val64: u64,
@@ -1087,7 +1087,7 @@ fn new_with_construction3() {
 
 #[test]
 fn new_with_construction4() {
-    #[bitfield(u32, default: 0x8000_0000)]
+    #[bitfield(u32, default = 0x8000_0000)]
     struct Test2 {
         #[bits(12..=27, w)]
         c: u16,
@@ -1109,7 +1109,7 @@ fn new_with_construction4() {
 
 #[test]
 fn new_with_construction5() {
-    #[bitfield(u8, default: 0)]
+    #[bitfield(u8, default = 0)]
     struct Test2 {
         #[bits(0..=7, rw)]
         val8: u8,
@@ -1121,7 +1121,7 @@ fn new_with_construction5() {
 
 #[test]
 fn new_with_construction_array1() {
-    #[bitfield(u32, default: 0)]
+    #[bitfield(u32, default = 0)]
     struct BytesInU32 {
         #[bits(0..=7, rw)]
         bytes: [u8; 4],
@@ -1135,7 +1135,7 @@ fn new_with_construction_array1() {
 
 #[test]
 fn new_with_construction_array2() {
-    #[bitfield(u128, default: 0)]
+    #[bitfield(u128, default = 0)]
     struct WordsInU128 {
         #[bits(0..=15, w)]
         words: [u16; 8],
@@ -1149,7 +1149,7 @@ fn new_with_construction_array2() {
 
 #[test]
 fn new_with_construction_array3() {
-    #[bitfield(u32, default: 0)]
+    #[bitfield(u32, default = 0)]
     struct Nibbles {
         #[bits(0..=3, w, stride: 8)]
         even_nibbles: [u4; 4],
@@ -1224,6 +1224,32 @@ fn underlying_type_is_arbitrary_array_complete() {
 
 #[test]
 fn underlying_type_is_arbitrary_default() {
+    #[bitfield(u14, default = 0x567)]
+    struct Nibbles {
+        #[bits(0..=3, rw)]
+        first_nibble: u4,
+    }
+
+    assert_eq!(Nibbles::DEFAULT.raw_value(), u14::new(0x567));
+    assert_eq!(
+        Nibbles::new_with_raw_value(u14::new(123)).raw_value(),
+        u14::new(123)
+    );
+    assert_eq!(
+        Nibbles::new_with_raw_value(u14::new(0x127)).first_nibble(),
+        u4::new(0x7)
+    );
+    assert_eq!(
+        Nibbles::builder()
+            .with_first_nibble(u4::new(0x9))
+            .build()
+            .raw_value(),
+        u14::new(0x569)
+    );
+}
+
+#[test]
+fn underlying_type_is_arbitrary_default_old_syntax() {
     #[bitfield(u14, default: 0x567)]
     struct Nibbles {
         #[bits(0..=3, rw)]

--- a/bitbybit-tests/tests/bitfield_tests_legacy.rs
+++ b/bitbybit-tests/tests/bitfield_tests_legacy.rs
@@ -4,7 +4,7 @@ use bitbybit::bitfield;
 
 #[test]
 fn test_construction() {
-    #[bitfield(u32, default = 0)]
+    #[bitfield(u32, default: 0)]
     struct Test2 {}
 
     let t = Test2::DEFAULT;
@@ -16,7 +16,7 @@ fn test_construction() {
 
 #[test]
 fn test_getter_and_setter() {
-    #[bitfield(u128, default = 0)]
+    #[bitfield(u128, default: 0)]
     struct Test2 {
         #[bits(98..=127, rw)]
         val30: u30,
@@ -55,7 +55,7 @@ fn test_getter_and_setter() {
 
 #[test]
 fn test_getter_and_setter_arbitrary_uint() {
-    #[bitfield(u128, default = 0)]
+    #[bitfield(u128, default: 0)]
     struct Test2 {
         #[bits(4..=11, rw)]
         baudrate: u8,
@@ -78,7 +78,7 @@ fn test_getter_and_setter_arbitrary_uint() {
 
 #[test]
 fn test_bool() {
-    #[bitfield(u16, default = 0)]
+    #[bitfield(u16, default: 0)]
     struct Test {
         #[bit(0, rw)]
         bit0: bool,
@@ -114,7 +114,7 @@ fn test_bool() {
 
 #[test]
 fn test_u1() {
-    #[bitfield(u16, default = 0)]
+    #[bitfield(u16, default: 0)]
     struct Test {
         #[bit(0, rw)]
         bit0: u1,
@@ -205,7 +205,7 @@ fn signed_masking8and16() {
 
 #[test]
 fn signed_masking32and64() {
-    #[bitfield(u128, default = 0)]
+    #[bitfield(u128, default: 0)]
     struct Test {
         #[bits(32..=95, rw)]
         signed1: i64,
@@ -224,7 +224,7 @@ fn signed_masking32and64() {
 
 #[test]
 fn signed_masking128() {
-    #[bitfield(u128, default = 0)]
+    #[bitfield(u128, default: 0)]
     struct Test {
         #[bits(0..=127, rw)]
         signed0: i128,
@@ -236,7 +236,7 @@ fn signed_masking128() {
 
 #[test]
 fn signed_masking_array() {
-    #[bitfield(u128, default = 0)]
+    #[bitfield(u128, default: 0)]
     struct Test {
         #[bits(96..=127, rw)]
         signed3: i32,
@@ -267,7 +267,7 @@ fn signed_masking_array() {
 
 #[test]
 fn default_value() {
-    #[bitfield(u32, default = 0xDEADBEEF)]
+    #[bitfield(u32, default: 0xDEADBEEF)]
     struct Test {}
 
     let t = Test::DEFAULT;
@@ -277,7 +277,7 @@ fn default_value() {
 #[test]
 fn default_value_const() {
     const DEFAULT: u32 = 0xBADCAFE;
-    #[bitfield(u32, default = DEFAULT)]
+    #[bitfield(u32, default: DEFAULT)]
     struct Test {}
 
     let t = Test::DEFAULT;
@@ -298,7 +298,7 @@ fn more_struct_attributes() {
 #[test]
 fn documentation() {
     /// Test that documentation is properly applied to the output
-    #[bitfield(u32, default = 0x123)]
+    #[bitfield(u32, default: 0x123)]
     #[derive(Debug)]
     struct Test {
         /// This is a documented field
@@ -324,7 +324,7 @@ fn documentation() {
 
 #[test]
 fn proper_unmasking() {
-    #[bitfield(u16, default = 0)]
+    #[bitfield(u16, default: 0)]
     pub struct TestStruct {
         #[bits(0..=1, rw)]
         a: u2,
@@ -349,7 +349,7 @@ fn proper_unmasking() {
 
 #[test]
 fn just_one_bitrange() {
-    #[bitfield(u16, default = 0)]
+    #[bitfield(u16, default: 0)]
     pub struct JustOneBitRange {
         #[bits(0..=15, rw)]
         a: i16,
@@ -363,18 +363,18 @@ fn just_one_bitrange() {
 
 #[test]
 fn repeated_bitrange_single_bits_with_stride() {
-    #[bitfield(u64, default = 0)]
+    #[bitfield(u64, default: 0)]
     pub struct NibbleBits64 {
-        #[bit(0, rw, stride = 4)]
+        #[bit(0, rw, stride: 4)]
         nibble_bit0: [bool; 16],
 
-        #[bit(1, rw, stride = 4)]
+        #[bit(1, rw, stride: 4)]
         nibble_bit1: [bool; 16],
 
-        #[bit(2, rw, stride = 4)]
+        #[bit(2, rw, stride: 4)]
         nibble_bit2: [bool; 16],
 
-        #[bit(3, rw, stride = 4)]
+        #[bit(3, rw, stride: 4)]
         nibble_bit3: [bool; 16],
     }
 
@@ -437,18 +437,18 @@ fn repeated_bitrange_single_bits_with_stride() {
 
 #[test]
 fn repeated_bitrange_single_u1_bits_with_stride() {
-    #[bitfield(u64, default = 0)]
+    #[bitfield(u64, default: 0)]
     pub struct NibbleBits64 {
-        #[bit(0, rw, stride = 4)]
+        #[bit(0, rw, stride: 4)]
         nibble_bit0: [u1; 16],
 
-        #[bit(1, rw, stride = 4)]
+        #[bit(1, rw, stride: 4)]
         nibble_bit1: [u1; 16],
 
-        #[bit(2, rw, stride = 4)]
+        #[bit(2, rw, stride: 4)]
         nibble_bit2: [u1; 16],
 
-        #[bit(3, rw, stride = 4)]
+        #[bit(3, rw, stride: 4)]
         nibble_bit3: [u1; 16],
     }
 
@@ -511,7 +511,7 @@ fn repeated_bitrange_single_u1_bits_with_stride() {
 
 #[test]
 fn repeated_bitrange_single_bits_without_stride() {
-    #[bitfield(u8, default = 0)]
+    #[bitfield(u8, default: 0)]
     pub struct Bits8 {
         #[bit(0, rw)]
         bit: [bool; 8],
@@ -534,7 +534,7 @@ fn repeated_bitrange_single_bits_without_stride() {
 
 #[test]
 fn repeated_bitrange_single_u1_bits_without_stride() {
-    #[bitfield(u8, default = 0)]
+    #[bitfield(u8, default: 0)]
     pub struct Bits8 {
         #[bit(0, rw)]
         bit: [u1; 8],
@@ -557,7 +557,7 @@ fn repeated_bitrange_single_u1_bits_without_stride() {
 
 #[test]
 fn repeated_bitrange_without_stride() {
-    #[bitfield(u64, default = 0)]
+    #[bitfield(u64, default: 0)]
     pub struct Nibble64 {
         #[bits(0..=3, rw)]
         nibble: [u4; 16],
@@ -593,9 +593,9 @@ fn repeated_bitrange_without_stride() {
 
 #[test]
 fn repeated_bitrange_with_stride_equals_width() {
-    #[bitfield(u64, default = 0)]
+    #[bitfield(u64, default: 0)]
     pub struct Nibble64 {
-        #[bits(0..=3, rw, stride = 4)]
+        #[bits(0..=3, rw, stride: 4)]
         nibble: [u4; 16],
     }
 
@@ -629,9 +629,9 @@ fn repeated_bitrange_with_stride_equals_width() {
 
 #[test]
 fn repeated_bitrange_with_stride_greater_than_width() {
-    #[bitfield(u64, default = 0)]
+    #[bitfield(u64, default: 0)]
     pub struct EvenNibble64 {
-        #[bits(0..=3, rw, stride = 8)]
+        #[bits(0..=3, rw, stride: 8)]
         even_nibble: [u4; 8],
     }
 
@@ -648,9 +648,9 @@ fn repeated_bitrange_with_stride_greater_than_width() {
 
 #[test]
 fn repeated_bitrange_with_stride_greater_than_width_basic_type() {
-    #[bitfield(u64, default = 0)]
+    #[bitfield(u64, default: 0)]
     pub struct EvenByte64 {
-        #[bits(0..=7, rw, stride = 16)]
+        #[bits(0..=7, rw, stride: 16)]
         even_byte: [u8; 4],
     }
 
@@ -665,7 +665,7 @@ fn repeated_bitrange_with_stride_greater_than_width_basic_type() {
 
 #[test]
 fn bitfield_with_enum_exhaustive() {
-    #[bitenum(u2, exhaustive = true)]
+    #[bitenum(u2, exhaustive: true)]
     #[derive(Eq, PartialEq, Debug)]
     pub enum ExhaustiveEnum {
         Zero = 0b00,
@@ -674,7 +674,7 @@ fn bitfield_with_enum_exhaustive() {
         Three = 0b11,
     }
 
-    #[bitfield(u64, default = 0)]
+    #[bitfield(u64, default: 0)]
     pub struct BitfieldWithEnum {
         #[bits(0..=1, rw)]
         e1: ExhaustiveEnum,
@@ -713,7 +713,7 @@ fn bitfield_with_enum_exhaustive() {
 
 #[test]
 fn bitfield_with_enum_nonexhaustive() {
-    #[bitenum(u2, exhaustive = false)]
+    #[bitenum(u2, exhaustive: false)]
     #[derive(Eq, PartialEq, Debug)]
     pub enum NonExhaustiveEnum {
         Zero = 0b00,
@@ -721,7 +721,7 @@ fn bitfield_with_enum_nonexhaustive() {
         Two = 0b10,
     }
 
-    #[bitfield(u64, default = 0)]
+    #[bitfield(u64, default: 0)]
     pub struct BitfieldWithEnumNonExhaustive {
         #[bits(2..=3, rw)]
         e2: Option<NonExhaustiveEnum>,
@@ -768,7 +768,7 @@ fn bitfield_with_enum_nonexhaustive() {
 
 #[test]
 fn bitfield_with_indexed_exhaustive_enum() {
-    #[bitenum(u2, exhaustive = true)]
+    #[bitenum(u2, exhaustive: true)]
     #[derive(Eq, PartialEq, Debug)]
     pub enum ExhaustiveEnum {
         Zero = 0b00,
@@ -777,7 +777,7 @@ fn bitfield_with_indexed_exhaustive_enum() {
         Three = 0b11,
     }
 
-    #[bitfield(u64, default = 0)]
+    #[bitfield(u64, default: 0)]
     pub struct BitfieldWithIndexedEnums {
         #[bits(0..=1, rw)]
         exhaustive: [ExhaustiveEnum; 8],
@@ -806,7 +806,7 @@ fn bitfield_with_indexed_exhaustive_enum() {
 
 #[test]
 fn bitfield_with_indexed_nonexhaustive_enum() {
-    #[bitenum(u2, exhaustive = false)]
+    #[bitenum(u2, exhaustive: false)]
     #[derive(Eq, PartialEq, Debug)]
     pub enum NonExhaustiveEnum {
         Zero = 0b00,
@@ -814,7 +814,7 @@ fn bitfield_with_indexed_nonexhaustive_enum() {
         Two = 0b10,
     }
 
-    #[bitfield(u64, default = 0)]
+    #[bitfield(u64, default: 0)]
     pub struct BitfieldWithIndexedEnums {
         #[bits(0..=1, rw)]
         nonexhaustive: [Option<NonExhaustiveEnum>; 8],
@@ -843,7 +843,7 @@ fn bitfield_with_indexed_nonexhaustive_enum() {
 
 #[test]
 fn bitfield_with_u8_enum() {
-    #[bitenum(u8, exhaustive = false)]
+    #[bitenum(u8, exhaustive: false)]
     #[derive(Eq, PartialEq, Debug)]
     pub enum NonExhaustiveEnum {
         Zero = 0b00,
@@ -851,7 +851,7 @@ fn bitfield_with_u8_enum() {
         Two = 0b10000010,
     }
 
-    #[bitfield(u64, default = 0)]
+    #[bitfield(u64, default: 0)]
     pub struct BitfieldWithIndexedEnums {
         #[bits(6..=13, rw)]
         val8: Option<NonExhaustiveEnum>,
@@ -878,14 +878,14 @@ fn bitfield_with_u8_enum() {
 
 #[test]
 fn bitfield_with_singlebit_enum() {
-    #[bitenum(u1, exhaustive = true)]
+    #[bitenum(u1, exhaustive: true)]
     #[derive(Eq, PartialEq, Debug)]
     enum BitEnum {
         Wrong = 0,
         Correct = 1,
     }
 
-    #[bitfield(u32, default = 0)]
+    #[bitfield(u32, default: 0)]
     struct BitfieldWithBitEnum {
         #[bit(6, rw)]
         bit: BitEnum,
@@ -942,7 +942,7 @@ fn with_derive_default() {
 fn default_value_automatically_implements_default() {
     // Early versions didn't automatically implement Default - ensure that this still compiles
     // (though we emit a compiler warning)
-    #[bitfield(u32, default = 2)]
+    #[bitfield(u32, default: 2)]
     #[derive(Eq, PartialEq, Debug)]
     struct Test {}
 
@@ -954,7 +954,7 @@ fn default_value_automatically_implements_default() {
 
 #[test]
 fn new_can_still_be_called() {
-    #[bitfield(u32, default = 567)]
+    #[bitfield(u32, default: 567)]
     #[derive(Eq, PartialEq, Debug)]
     struct Test {}
 
@@ -966,9 +966,9 @@ fn new_can_still_be_called() {
 #[test]
 #[should_panic]
 fn array_out_of_bounds_read() {
-    #[bitfield(u64, default = 0)]
+    #[bitfield(u64, default: 0)]
     pub struct OutOfBoundsTests {
-        #[bit(0, rw, stride = 4)]
+        #[bit(0, rw, stride: 4)]
         nibble_bit0: [u1; 15],
     }
 
@@ -979,9 +979,9 @@ fn array_out_of_bounds_read() {
 #[test]
 #[should_panic]
 fn array_out_of_bounds_write() {
-    #[bitfield(u64, default = 0)]
+    #[bitfield(u64, default: 0)]
     pub struct OutOfBoundsTests {
-        #[bit(0, rw, stride = 4)]
+        #[bit(0, rw, stride: 4)]
         nibble_bit0: [u1; 15],
     }
 
@@ -992,14 +992,14 @@ fn array_out_of_bounds_write() {
 #[allow(non_camel_case_types)]
 #[test]
 fn reserved_identifiers() {
-    #[bitenum(u1, exhaustive = true)]
+    #[bitenum(u1, exhaustive: true)]
     #[derive(PartialEq, Eq, Debug)]
     enum BitEnum {
         r#priv = 0,
         r#enum = 1,
     }
 
-    #[bitfield(u32, default = 0)]
+    #[bitfield(u32, default: 0)]
     #[derive(PartialEq, Eq, Debug)]
     struct BitfieldWithBitEnum {
         #[bit(6, rw)]
@@ -1025,7 +1025,7 @@ fn reserved_identifiers() {
 
 #[test]
 fn new_with_construction1() {
-    #[bitfield(u128, default = 0)]
+    #[bitfield(u128, default: 0)]
     struct Test2 {
         #[bits(98..=127, rw)]
         val30: u30,
@@ -1061,7 +1061,7 @@ fn new_with_construction1() {
 
 #[test]
 fn new_with_construction2() {
-    #[bitfield(u128, default = 0)]
+    #[bitfield(u128, default: 0)]
     struct Test2 {
         #[bits(0..=127, rw)]
         val128: u128,
@@ -1075,7 +1075,7 @@ fn new_with_construction2() {
 
 #[test]
 fn new_with_construction3() {
-    #[bitfield(u64, default = 0)]
+    #[bitfield(u64, default: 0)]
     struct Test2 {
         #[bits(0..=63, rw)]
         val64: u64,
@@ -1087,7 +1087,7 @@ fn new_with_construction3() {
 
 #[test]
 fn new_with_construction4() {
-    #[bitfield(u32, default = 0x8000_0000)]
+    #[bitfield(u32, default: 0x8000_0000)]
     struct Test2 {
         #[bits(12..=27, w)]
         c: u16,
@@ -1109,7 +1109,7 @@ fn new_with_construction4() {
 
 #[test]
 fn new_with_construction5() {
-    #[bitfield(u8, default = 0)]
+    #[bitfield(u8, default: 0)]
     struct Test2 {
         #[bits(0..=7, rw)]
         val8: u8,
@@ -1121,7 +1121,7 @@ fn new_with_construction5() {
 
 #[test]
 fn new_with_construction_array1() {
-    #[bitfield(u32, default = 0)]
+    #[bitfield(u32, default: 0)]
     struct BytesInU32 {
         #[bits(0..=7, rw)]
         bytes: [u8; 4],
@@ -1135,7 +1135,7 @@ fn new_with_construction_array1() {
 
 #[test]
 fn new_with_construction_array2() {
-    #[bitfield(u128, default = 0)]
+    #[bitfield(u128, default: 0)]
     struct WordsInU128 {
         #[bits(0..=15, w)]
         words: [u16; 8],
@@ -1149,12 +1149,12 @@ fn new_with_construction_array2() {
 
 #[test]
 fn new_with_construction_array3() {
-    #[bitfield(u32, default = 0)]
+    #[bitfield(u32, default: 0)]
     struct Nibbles {
-        #[bits(0..=3, w, stride = 8)]
+        #[bits(0..=3, w, stride: 8)]
         even_nibbles: [u4; 4],
 
-        #[bits(4..=7, w, stride = 8)]
+        #[bits(4..=7, w, stride: 8)]
         odd_nibbles: [u4; 4],
     }
 
@@ -1172,10 +1172,10 @@ fn without_default_complete() {
 
     #[bitfield(u32)]
     struct Nibbles {
-        #[bits(0..=3, w, stride = 8)]
+        #[bits(0..=3, w, stride: 8)]
         even_nibbles: [u4; 4],
 
-        #[bits(4..=7, w, stride = 8)]
+        #[bits(4..=7, w, stride: 8)]
         odd_nibbles: [u4; 3],
 
         #[bits(28..=31, rw)]
@@ -1224,7 +1224,7 @@ fn underlying_type_is_arbitrary_array_complete() {
 
 #[test]
 fn underlying_type_is_arbitrary_default() {
-    #[bitfield(u14, default = 0x567)]
+    #[bitfield(u14, default: 0x567)]
     struct Nibbles {
         #[bits(0..=3, rw)]
         first_nibble: u4,

--- a/bitbybit/CHANGELOG.md
+++ b/bitbybit/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## bitbybit 1.3.0
+
+### Changed
+
+- Switched default attribute argument syntax from field type to assignment type (colon field style is still allowed, but might be deprecated in the future):
+```rs
+#[bitenum(u2, exhaustive = true)]
+enum ExhaustiveEnum {
+    Zero = 0b00,
+    One = 0b01,
+    Two = 0b10,
+    Three = 0b11,
+}
+
+#[bitfield(u64, default = 0)]
+struct BitfieldWithEnum {
+    #[bits(2..=3, rw)]
+    e2: Option<NonExhaustiveEnum>,
+
+    #[bits(0..=1, rw)]
+    e1: ExhaustiveEnum,
+}
+```
+
 ## bitbybit 1.2.2
 
 ### Added

--- a/bitbybit/Cargo.toml
+++ b/bitbybit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitbybit"
-version = "1.2.2"
+version = "1.3.0"
 authors = ["Daniel Lehmann <danlehmannmuc@gmail.com>"]
 edition = "2021"
 description = "Efficient implementation of bit-fields where several numbers are packed within a larger number and bit-enums. Useful for drivers, so it works in no_std environments"

--- a/bitbybit/README.md
+++ b/bitbybit/README.md
@@ -5,7 +5,7 @@ or networking code).
 
 Some highlights:
 
-- Highly efficient and 100% safe code that is just as good and hand-writen shifts and masks,
+- Highly efficient and 100% safe code that is just as good and hand-written shifts and masks,
 - Full compatibility with const contexts,
 - Useable in no-std environments,
 - Strong compile time guarantees (for example, taking 5 bits out of a bitfield and putting them into another won't even
@@ -57,14 +57,14 @@ Very often, fields aren't just numbers but really enums. This is supported by fi
 that inside of a bitfield:
 
 ```rs
-#[bitenum(u2, exhaustive: false)]
+#[bitenum(u2, exhaustive = false)]
 enum NonExhaustiveEnum {
     Zero = 0b00,
     One = 0b01,
     Two = 0b10,
 }
 
-#[bitenum(u2, exhaustive: true)]
+#[bitenum(u2, exhaustive = true)]
 enum ExhaustiveEnum {
     Zero = 0b00,
     One = 0b01,
@@ -72,7 +72,7 @@ enum ExhaustiveEnum {
     Three = 0b11,
 }
 
-#[bitfield(u64, default: 0)]
+#[bitfield(u64, default = 0)]
 struct BitfieldWithEnum {
     #[bits(2..=3, rw)]
     e2: Option<NonExhaustiveEnum>,
@@ -96,7 +96,7 @@ Sometimes, bits inside bitfields are repeated. To support this, this crate allow
 example, the following struct gives read/write access to each individual nibble (hex character) of a u64:
 
 ```rs
-#[bitfield(u64, default: 0)]
+#[bitfield(u64, default = 0)]
 struct Nibble64 {
      #[bits(0..=3, rw)]
      nibble: [u4; 16],
@@ -107,18 +107,18 @@ Arrays can also have a stride. This is useful in the case of multiple smaller va
 following definition provides access to each bit of each nibble:
 
 ```rs
-#[bitfield(u64, default: 0)]
+#[bitfield(u64, default = 0)]
 struct NibbleBits64 {
-    #[bit(0, rw, stride: 4)]
+    #[bit(0, rw, stride = 4)]
     nibble_bit0: [bool; 16],
 
-    #[bit(1, rw, stride: 4)]
+    #[bit(1, rw, stride = 4)]
     nibble_bit1: [bool; 16],
 
-    #[bit(2, rw, stride: 4)]
+    #[bit(2, rw, stride = 4)]
     nibble_bit2: [bool; 16],
 
-    #[bit(3, rw, stride: 4)]
+    #[bit(3, rw, stride = 4)]
     nibble_bit3: [bool; 16],
 }
 ```
@@ -134,7 +134,7 @@ let a = NibbleBits64::new_with_raw_value(0x43218765);
 However, pretty often a specific value can be considered the default (for example 0). This can be specified like this:
 
 ```rs
-#[bitfield(u32, default: 0x1234)]
+#[bitfield(u32, default = 0x1234)]
 struct Bitfield1 {
   #[bits(0..=3, rw)]
   nibble: [u4; 4],

--- a/bitbybit/src/bitenum.rs
+++ b/bitbybit/src/bitenum.rs
@@ -23,7 +23,7 @@ pub fn bitenum(args: TokenStream, input: TokenStream) -> TokenStream {
         token_stream: TokenStream2,
     ) {
         match next_expected {
-            None => panic!("bitenum!: Seen {}, but didn't expect anything. Example of valid syntax: #[bitenum(u3, exhaustive: false)]", token_stream),
+            None => panic!("bitenum!: Seen {}, but didn't expect anything. Example of valid syntax: #[bitenum(u3, exhaustive = false)]", token_stream),
             Some(ArgumentType::Exhaustive) => {
                 *default_value = Some(token_stream);
             }
@@ -33,9 +33,9 @@ pub fn bitenum(args: TokenStream, input: TokenStream) -> TokenStream {
         match arg {
             TokenTree::Punct(p) => match p.as_char() {
                 ',' => next_expected = None,
-                ':' => {}
+                '=' | ':' => (),
                 _ => panic!(
-                    "bitenum!: Expected ',' or ':' in argument list. Seen '{}'",
+                    "bitenum!: Expected ',', '=' or ':' in argument list. Seen '{}'",
                     p
                 ),
             },
@@ -91,7 +91,7 @@ pub fn bitenum(args: TokenStream, input: TokenStream) -> TokenStream {
                 handle_next_expected(&next_expected, default_value, literal.to_token_stream());
             }
             _ => {
-                panic!("bitenum!: Unexpected token. Example of valid syntax: #[bitenum(u32, exhaustive: true)]")
+                panic!("bitenum!: Unexpected token. Example of valid syntax: #[bitenum(u32, exhaustive = true)]")
             }
         }
     }
@@ -134,7 +134,7 @@ pub fn bitenum(args: TokenStream, input: TokenStream) -> TokenStream {
                 _ => panic!("bitenum!: Unhandled bits. Supported up to u64"),
             },
             None => panic!(
-                "bitenum!: datatype argument needed, for example #[bitenum(u4, exhaustive: true)"
+                "bitenum!: datatype argument needed, for example #[bitenum(u4, exhaustive = true)"
             ),
         };
 
@@ -150,7 +150,7 @@ pub fn bitenum(args: TokenStream, input: TokenStream) -> TokenStream {
             "true" => Exhaustiveness::True,
             "false" => Exhaustiveness::False,
             "conditional" => Exhaustiveness::Conditional,
-            _ => panic!("bitenum!: \"exhaustive\" must be \"true\", \"false\" or \"conditional\""),
+            _ => panic!(r#"bitenum!: "exhaustive" must be "true", "false" or "conditional""#),
         })
         .unwrap_or(Exhaustiveness::False);
 
@@ -203,11 +203,11 @@ pub fn bitenum(args: TokenStream, input: TokenStream) -> TokenStream {
 
     if uses_conditional {
         if exhaustiveness != Exhaustiveness::Conditional {
-            panic!("bitenum!: If any values are marked as conditional (using the cfg attribute), the enum must be marked as 'exhaustive: conditional'");
+            panic!("bitenum!: If any values are marked as conditional (using the cfg attribute), the enum must be marked as 'exhaustive = conditional'");
         }
     } else {
         if exhaustiveness == Exhaustiveness::Conditional {
-            panic!("bitenum!: No values are conditionally compiled using cfg, so the enum must not be marked as conditional. Change to 'exhaustive: true' or 'exhaustive: false'");
+            panic!("bitenum!: No values are conditionally compiled using cfg, so the enum must not be marked as conditional. Change to 'exhaustive = true' or 'exhaustive = false'");
         }
     }
 
@@ -224,7 +224,7 @@ pub fn bitenum(args: TokenStream, input: TokenStream) -> TokenStream {
         }
         Exhaustiveness::False => {
             if emitted_variants.len() == possible_maximum_variants as usize {
-                panic!("bitenum!: Enum is exhaustive, but not marked accordingly. Add 'exhaustive: true'")
+                panic!("bitenum!: Enum is exhaustive, but not marked accordingly. Add 'exhaustive = true'")
             }
             true
         }
@@ -239,7 +239,7 @@ pub fn bitenum(args: TokenStream, input: TokenStream) -> TokenStream {
     // - exclude unhandled integers, followed by transmute (unsafe)
     // For now, we'll go with the first option. If we find that the compiler generates bad code,
     // we can switch to the second option (as we required all values to be literals, so we can
-    // analyse used vs unused ranges)
+    // analyze used vs unused ranges)
 
     let case_values: Vec<TokenStream2> = emitted_variants
         .iter()

--- a/bitbybit/src/bitfield.rs
+++ b/bitbybit/src/bitfield.rs
@@ -114,7 +114,7 @@ pub fn bitfield(args: TokenStream, input: TokenStream) -> TokenStream {
             },
             TokenTree::Ident(sym) => {
                 if next_expected.is_some() {
-                    // We might end up here if we refer to a constant, like 'default: SOME_CONSTANT'
+                    // We might end up here if we refer to a constant, like 'default = SOME_CONSTANT'
                     handle_next_expected(&next_expected, &mut default_value, sym.to_token_stream());
                 } else {
                     match sym.to_string().as_str() {
@@ -132,7 +132,7 @@ pub fn bitfield(args: TokenStream, input: TokenStream) -> TokenStream {
                 }
             }
             TokenTree::Literal(literal) => {
-                // We end up here if we see a literal, like 'default: 0x1234'
+                // We end up here if we see a literal, like 'default = 0x1234'
                 handle_next_expected(
                     &next_expected,
                     &mut default_value,

--- a/bitbybit/src/bitfield.rs
+++ b/bitbybit/src/bitfield.rs
@@ -96,7 +96,7 @@ pub fn bitfield(args: TokenStream, input: TokenStream) -> TokenStream {
         token_stream: TokenStream2,
     ) {
         match next_expected {
-            None => panic!("bitfield!: Unexpected token {}. Example of valid syntax: #[bitfield(u32, default: 0)]", token_stream),
+            None => panic!("bitfield!: Unexpected token {}. Example of valid syntax: #[bitfield(u32, default = 0)]", token_stream),
             Some(ArgumentType::Default) => {
                 *default_value = Some(token_stream);
             }
@@ -104,11 +104,11 @@ pub fn bitfield(args: TokenStream, input: TokenStream) -> TokenStream {
     }
     for arg in args.iter().skip(1) {
         match arg {
-            TokenTree::Punct(p) => match p.to_string().as_str() {
-                "," => next_expected = None,
-                ":" => {}
+            TokenTree::Punct(p) => match p.as_char() {
+                ',' => next_expected = None,
+                '=' | ':' => (),
                 _ => panic!(
-                    "bitfield!: Expected ',' or ':' in argument list. Saw '{}'",
+                    "bitfield!: Expected ',', '=' or ':' in argument list. Saw '{}'",
                     p
                 ),
             },
@@ -139,7 +139,7 @@ pub fn bitfield(args: TokenStream, input: TokenStream) -> TokenStream {
                     literal.to_token_stream(),
                 );
             }
-            t => panic!("bitfield!: Unexpected token {}. Example of valid syntax: #[bitfield(u32, default: 0)]", t),
+            t => panic!("bitfield!: Unexpected token {}. Example of valid syntax: #[bitfield(u32, default = 0)]", t),
         }
     }
 
@@ -873,12 +873,14 @@ fn parse_field(base_data_size: usize, field: &Field) -> Result<FieldDefinition, 
 
                 // *** Parse additional named arguments (at the moment just stride: X)
                 for argument in arguments.iter().skip(2) {
-                    let argument_elements: Vec<&str> =
-                        argument.split(':').map(|s| s.trim()).collect();
+                    let argument_elements: Vec<&str> = argument
+                        .split(|c| c == '=' || c == ':')
+                        .map(|s| s.trim())
+                        .collect();
                     if argument_elements.len() != 2 {
                         return Err(syn::Error::new_spanned(
                                 &attr.meta,
-                                format!("bitfield!: Named arguments have to be in the form of 'argument: value'. Seen: {:?}", argument_elements)
+                                format!("bitfield!: Named arguments have to be in the form of 'argument = value'. Seen: {:?}", argument_elements)
                             ).to_compile_error());
                     }
                     match argument_elements[0] {
@@ -1013,7 +1015,7 @@ fn parse_field(base_data_size: usize, field: &Field) -> Result<FieldDefinition, 
     }
 
     let (custom_type, getter_type, setter_type) = if field_type_size_from_data_type.is_none() {
-        // Test for optional type. We have to disect the Option<T> type to do that
+        // Test for optional type. We have to dissect the Option<T> type to do that
         let (inner_type, result_type) = if let Type::Path(type_path) = ty {
             if type_path.path.segments.len() != 1 {
                 panic!("Invalid path segment. Expected Enumeration or Option<Enumeration>");

--- a/bitbybit/src/lib.rs
+++ b/bitbybit/src/lib.rs
@@ -3,19 +3,21 @@ use proc_macro::TokenStream;
 mod bitenum;
 mod bitfield;
 
-/// Defines a bitfield: #[bitfield(<base-data-type>, default: 0)]
-/// <base-data-type> is a data type like u32 which is used to represent all the bits of the bitfield.
-/// default is an optional default when the bitfield is created
+/// Defines a bitfield: `#[bitfield(<base-data-type>, default = 0)]`
+/// `<base-data-type>` is a data type like [`u32`] which is used to represent all the bits of the bitfield.
+/// `default` is an optional default when the bitfield is created
 #[proc_macro_attribute]
 pub fn bitfield(args: TokenStream, input: TokenStream) -> TokenStream {
     bitfield::bitfield(args, input)
 }
 
-/// Defines a bitenum: `#[bitenum(<base-data-type>, exhaustive: true)]`
-/// <base-data-type> is a data type like `u2` ([`arbitrary_int::u2`]) or [`u8`]
+/// Defines a bitenum: `#[bitenum(<base-data-type>, exhaustive = true)]`
+/// `<base-data-type>` is a data type like [`u2`] or [`u8`]
 /// which is used the actually store the value of the bitfield.
 /// `exhaustive` specifies whether the bitenum includes all possible value of the
-/// given base data type (for example, a bitenum over u2 with 4 values is exhaustive)
+/// given base data type (for example, a bitenum over [`u2`] with 4 values is exhaustive)
+///
+/// [`u2`]: arbitrary_int::u2
 #[proc_macro_attribute]
 pub fn bitenum(args: TokenStream, input: TokenStream) -> TokenStream {
     bitenum::bitenum(args, input)


### PR DESCRIPTION
As this seems the agreed upon standard for attribute macros

- colon syntax still works too
- updated all the docs and tests
- added sanity tests for the field syntax
- small typos in docs, made top level docs more consistent