### PR TITLE
Fix bug where braces are missing when a regular int is being produced

### DIFF
--- a/bitbybit/CHANGELOG.md
+++ b/bitbybit/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## bitbybit 1.3.1
+
+### Fixed
+- Fixed a compilation error when non-contiguous ranges would produce a regular int (u8, u16, etc.).
+
 ## bitbybit 1.3.0
 
 ### Changed

--- a/bitbybit/Cargo.toml
+++ b/bitbybit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitbybit"
-version = "1.3.0"
+version = "1.3.1"
 authors = ["Daniel Lehmann <danlehmannmuc@gmail.com>"]
 edition = "2021"
 description = "Efficient implementation of bit-fields where several numbers are packed within a larger number and bit-enums. Useful for drivers, so it works in no_std environments"

--- a/bitbybit/src/bitfield/codegen.rs
+++ b/bitbybit/src/bitfield/codegen.rs
@@ -145,7 +145,7 @@ fn getter_packed(
         })
     });
     quote! {
-        #(#expressions)|*
+        (#(#expressions)|*)
     }
 }
 


### PR DESCRIPTION
This was reported in issue #24. The fix itself is two characters - added a ton of test coverage to go through all combinations of regular and arbitrary ints.