### PR TITLE
Introduce ZERO constant

### DIFF
--- a/bitbybit-tests/src/bitfield_tests.rs
+++ b/bitbybit-tests/src/bitfield_tests.rs
@@ -15,6 +15,18 @@ fn test_construction() {
 }
 
 #[test]
+fn test_zero() {
+    #[bitfield(u32)]
+    struct TestA {}
+
+    #[bitfield(u32, default = 0x123)]
+    struct TestB {}
+
+    assert_eq!(0, TestA::ZERO.raw_value());
+    assert_eq!(0, TestB::ZERO.raw_value());
+}
+
+#[test]
 fn test_getter_and_with() {
     #[bitfield(u128, default = 0)]
     struct Test2 {
@@ -1548,7 +1560,6 @@ fn test_noncontiguous_ranges_array_with_interleaving_and_builder() {
         0b10110100
     );
 }
-
 
 #[test]
 fn test_getter_and_setter() {

--- a/bitbybit/src/bitfield/mod.rs
+++ b/bitbybit/src/bitfield/mod.rs
@@ -251,6 +251,12 @@ pub fn bitfield(args: TokenStream, input: TokenStream) -> TokenStream {
         quote! { #base_data_type::#extract(self.raw_value, 0) }
     };
 
+    let zero = if base_data_size.exposed == base_data_size.internal {
+        quote! { 0 }
+    } else {
+        quote! { #base_data_type::new(0) }
+    };
+
     let expanded = quote! {
         #[derive(Copy, Clone)]
         #[repr(C)]
@@ -260,6 +266,8 @@ pub fn bitfield(args: TokenStream, input: TokenStream) -> TokenStream {
         }
 
         impl #struct_name {
+            pub const ZERO: Self = Self::new_with_raw_value(#zero);
+
             #default_constructor
             /// Returns the underlying raw value of this bitfield
             #[inline]


### PR DESCRIPTION
This is a shortcut for `A::new_with_raw_value(0)`.

No changes to semantics around when e.g. the builder syntax exists