### PR TITLE
Added method chaining support to `set_*` methods

### DIFF
--- a/bitbybit-tests/src/bitfield_tests.rs
+++ b/bitbybit-tests/src/bitfield_tests.rs
@@ -1581,11 +1581,16 @@ fn test_getter_and_setter() {
     assert_eq!(0xE0, t.baudrate());
     assert_eq!(u4::new(0x6), t.some_other_bits());
 
-    t.set_baudrate(0x12);
-    t.set_some_other_bits(u4::new(0x2));
+    t.set_baudrate(0x12).set_some_other_bits(u4::new(0x2));
     assert_eq!(0x12, t.baudrate());
     assert_eq!(u4::new(0x2), t.some_other_bits());
     assert_eq!(0xAE42_315A_2134_FE06_3412_345A_2134_F122, t.raw_value);
+
+    t.set_baudrate(0x43);
+    t.set_some_other_bits(u4::new(0x5));
+    assert_eq!(0x43, t.baudrate());
+    assert_eq!(u4::new(0x5), t.some_other_bits());
+    assert_eq!(0xAE42_315A_2134_FE06_3412_345A_2134_F435, t.raw_value);
 }
 
 #[test]
@@ -1603,9 +1608,14 @@ fn test_getter_and_setter_arbitrary_uint() {
     assert_eq!(0xE0, t.baudrate());
     assert_eq!(u4::new(0x6), t.some_other_bits());
 
-    t.set_baudrate(0x12);
-    t.set_some_other_bits(u4::new(0x2));
+    t.set_baudrate(0x12).set_some_other_bits(u4::new(0x2));
     assert_eq!(0x12, t.baudrate());
     assert_eq!(u4::new(0x2), t.some_other_bits());
     assert_eq!(0xF122, t.raw_value);
+
+    t.set_baudrate(0x43);
+    t.set_some_other_bits(u4::new(0x5));
+    assert_eq!(0x43, t.baudrate());
+    assert_eq!(u4::new(0x5), t.some_other_bits());
+    assert_eq!(0xF435, t.raw_value);
 }

--- a/bitbybit/src/bitfield/codegen.rs
+++ b/bitbybit/src/bitfield/codegen.rs
@@ -1,4 +1,4 @@
-use crate::bitfield::{with_name, setter_name, BaseDataSize, CustomType, FieldDefinition, BITCOUNT_BOOL};
+use crate::bitfield::{prefix_name, BaseDataSize, CustomType, FieldDefinition, BITCOUNT_BOOL};
 use proc_macro2::{Ident, TokenStream as TokenStream2, TokenStream, TokenTree};
 use quote::quote;
 use std::ops::Range;
@@ -91,8 +91,8 @@ pub fn generate(
 
             let new_raw_value = setter_new_raw_value(&one, &argument_converted, field_definition, base_data_size, internal_base_data_type);
 
-            let setter_name = setter_name(field_name);
-            let with_name = with_name(field_name);
+            let setter_name = prefix_name(field_name, "set_");
+            let with_name = prefix_name(field_name, "with_");
 
             if let Some(array) = field_definition.array {
                 let indexed_count = array.0;
@@ -372,7 +372,7 @@ pub fn make_builder(
     for field_definition in field_definitions {
         if let Some(setter_type) = field_definition.setter_type.as_ref() {
             let field_name = &field_definition.field_name;
-            let with_name = with_name(field_name);
+            let with_name = prefix_name(field_name, "with_");
 
             let (field_mask, value_transform, argument_type) = if let Some(array) =
                 field_definition.array

--- a/bitbybit/src/bitfield/codegen.rs
+++ b/bitbybit/src/bitfield/codegen.rs
@@ -107,9 +107,10 @@ pub fn generate(
                     }
                     #(#doc_comment)*
                     #[inline]
-                    pub fn #setter_name(&mut self, index: usize, field_value: #setter_type) {
+                    pub fn #setter_name(&mut self, index: usize, field_value: #setter_type) -> &mut Self {
                         assert!(index < #indexed_count);
                         self.raw_value = #new_raw_value;
+                        self
                     }
                 }
             } else {
@@ -123,8 +124,9 @@ pub fn generate(
                     }
                     #(#doc_comment)*
                     #[inline]
-                    pub fn #setter_name(&mut self, field_value: #setter_type) {
+                    pub fn #setter_name(&mut self, field_value: #setter_type) -> &mut Self {
                         self.raw_value = #new_raw_value;
+                        self
                     }
                 }
             }

--- a/bitbybit/src/bitfield/mod.rs
+++ b/bitbybit/src/bitfield/mod.rs
@@ -283,7 +283,7 @@ pub fn bitfield(args: TokenStream, input: TokenStream) -> TokenStream {
     TokenStream::from(expanded)
 }
 
-fn with_name(field_name: &Ident) -> Ident {
+fn prefix_name(field_name: &Ident, prefix: &str) -> Ident {
     // The field might have started with r#. If so, it was likely used for a keyword. This can be dropped here
     let field_name_without_prefix = {
         let s = field_name.to_string();
@@ -294,23 +294,8 @@ fn with_name(field_name: &Ident) -> Ident {
         }
     };
 
-    syn::parse_str::<Ident>(format!("with_{}", field_name_without_prefix).as_str())
-        .unwrap_or_else(|_| panic!("bitfield!: Error creating setter name"))
-}
-
-fn setter_name(field_name: &Ident) -> Ident {
-    // The field might have started with r#. If so, it was likely used for a keyword. This can be dropped here
-    let field_name_without_prefix = {
-        let s = field_name.to_string();
-        if s.starts_with("r#") {
-            s[2..].to_string()
-        } else {
-            s
-        }
-    };
-
-    syn::parse_str::<Ident>(format!("set_{}", field_name_without_prefix).as_str())
-        .unwrap_or_else(|_| panic!("bitfield!: Error creating setter name"))
+    syn::parse_str::<Ident>(format!("{prefix}{}", field_name_without_prefix).as_str())
+        .unwrap_or_else(|_| panic!("bitfield!: Error prefixing name"))
 }
 
 struct FieldDefinition {


### PR DESCRIPTION
This is an addition to #59, which I forgot to commit a few weeks ago. The primary addition of this pull request is to make the set methods support method chaining.

While compatibility is good for simple raw value cases, such as:

```rust
#[bitfield(u16, default = 0)]
struct MyStruct {
    #[bits(8..=15, rw)]
    field_1: u8,

    #[bits(0..=7, rw)]
    field_2: u8,
}

let mut test = MyStruct::default();
test.set_field_1(80)
    .set_field_2(4);
```

There is a caveat when it comes to modifying the existing value:

```rust
let mut test = MyStruct::default();
test.set_field_1(test.field_1() + 4)
    .set_field_2(test.field_2() + 2);
```

As this requires an immutable borrow after the mutable borrow is already taken.

One potential solution is the implementation of a set of `modify_*` functions, that take an FnOnce, passing the current field value to it, returning the new value:

```rust
let mut test = MyStruct::default();
test.modify_field_1(|cur_field_1| cur_field_1 + 4)
    .modify_field_2(|cur_field_2| cur_field_2 + 2);
```

However this would add yet another method, and some more complex syntax, and I'm not sure that's worth the small benefit of method chaining support. Not to mention I don't have the time or desire to write the implementation for such a feature, when the alternative is to simply not chain more complex cases:

```rust
let mut test = MyStruct::default();
test.set_field_1(test.field_1() + 4);
test.set_field_2(test.field_2() + 2);
```