### PR TITLE
Allow fully qualified paths for bitenum and arbitrary_int fields

### DIFF
--- a/bitbybit/CHANGELOG.md
+++ b/bitbybit/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## unreleased
+
+### Fixed
+
+- Allow qualified paths for `arbitrary_int` fields as well es (optional) `bitenum` fields.
+
 ## bitbybit 1.3.3
 
 ### Added

--- a/bitbybit/src/bit_size.rs
+++ b/bitbybit/src/bit_size.rs
@@ -2,7 +2,7 @@ use proc_macro2::TokenStream;
 use quote::quote;
 use quote::spanned::Spanned;
 
-const BAD_SIZE: &'static str = "The specified storage size is invalid, valid is in range 1..=64";
+const BAD_SIZE: &str = "The specified storage size is invalid, valid is in range 1..=64";
 
 /// Explicitly declared storage type for `bitenum` enums.
 pub(crate) struct Bits {

--- a/bitbybit/src/bitenum.rs
+++ b/bitbybit/src/bitenum.rs
@@ -248,8 +248,8 @@ pub(crate) fn fallback_impl(input: &syn::ItemEnum) -> TokenStream {
 }
 pub(crate) fn bitenum(config: Config, input: &syn::ItemEnum) -> syn::Result<TokenStream> {
     let config = config.explicit()?;
-    check_explicit_conditional(&config, &input)?;
-    check_explicit_exhaustive(&config, &input)?;
+    check_explicit_conditional(&config, input)?;
+    check_explicit_exhaustive(&config, input)?;
 
     let bits = config.bits;
     let (base_type, qualified_type) = (bits.base_type()?, bits.qualified_path()?);


### PR DESCRIPTION
This PR also contains clippy fixes and some improvements for Error handling where I replaced panics with spanned errors.

What do you think about adding some error tests using https://docs.rs/trybuild/latest/trybuild/ ?