### PR TITLE
Add missing doc comments to pass builds using #[deny(missing_docs)]

### DIFF
--- a/bitbybit-tests/src/doc.rs
+++ b/bitbybit-tests/src/doc.rs
@@ -1,0 +1,12 @@
+//! This ensures that callers can compile even if they specify missing_docs
+#![deny(missing_docs)]
+
+use bitbybit::bitfield;
+
+/// We put this here to verify the missing_docs above
+#[bitfield(u32, default = 0)]
+pub struct DocCheck {
+    /// A field
+    #[bits(2..=17, rw)]
+    a: u16,
+}

--- a/bitbybit-tests/src/lib.rs
+++ b/bitbybit-tests/src/lib.rs
@@ -6,3 +6,5 @@ mod bitenum_tests;
 mod bitfield_tests;
 #[cfg(test)]
 mod bitfield_tests_legacy;
+#[cfg(test)]
+pub mod doc;

--- a/bitbybit/CHANGELOG.md
+++ b/bitbybit/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Changelog
 
-## unreleased
+## bitbybit 1.4.0
 
 ### Fixed
 
 - Allow qualified paths for `arbitrary_int` fields as well es (optional) `bitenum` fields.
+- Fix the build for users that `#[deny(missing_docs)]`
 
 ## bitbybit 1.3.3
 

--- a/bitbybit/Cargo.toml
+++ b/bitbybit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitbybit"
-version = "1.3.3"
+version = "1.4.0"
 authors = ["Daniel Lehmann <danlehmannmuc@gmail.com>"]
 edition = "2021"
 description = "Efficient implementation of bit-fields where several numbers are packed within a larger number and bit-enums. Useful for drivers, so it works in no_std environments"

--- a/bitbybit/src/bitfield/codegen.rs
+++ b/bitbybit/src/bitfield/codegen.rs
@@ -366,7 +366,8 @@ pub fn make_builder(
         Vec::with_capacity(field_definitions.len() + 2);
 
     new_with_builder_chain.push(quote! {
-       #struct_vis struct #builder_struct_name<const MASK: #internal_base_data_type>(#struct_name);
+        /// Partial builder struct
+        #struct_vis struct #builder_struct_name<const MASK: #internal_base_data_type>(#struct_name);
     });
 
     for field_definition in field_definitions {

--- a/bitbybit/src/bitfield/mod.rs
+++ b/bitbybit/src/bitfield/mod.rs
@@ -211,9 +211,9 @@ pub fn bitfield(args: TokenStream, input: TokenStream) -> TokenStream {
                 #default_raw_value
 
                 #[doc = #comment]
-                #[inline]
                 pub const DEFAULT: Self = Self::new_with_raw_value(Self::DEFAULT_RAW_VALUE);
 
+                /// Creates a new instance of this struct using the default value
                 #[deprecated(note = #deprecated_warning)]
                 pub const fn new() -> Self {
                     Self::DEFAULT
@@ -288,6 +288,11 @@ pub fn bitfield(args: TokenStream, input: TokenStream) -> TokenStream {
         quote! { #base_data_type::new(0) }
     };
 
+    let zero_comment = format!(
+        "Creates a new instance with a raw value of 0. Equivalent to [`Self::new_with_raw_value({})`].",
+        zero
+    );
+
     let expanded = quote! {
         #[derive(Copy, Clone)]
         #[repr(C)]
@@ -297,6 +302,7 @@ pub fn bitfield(args: TokenStream, input: TokenStream) -> TokenStream {
         }
 
         impl #struct_name {
+            #[doc = #zero_comment]
             pub const ZERO: Self = Self::new_with_raw_value(#zero);
 
             #default_constructor


### PR DESCRIPTION
While at it, also removed `#[inline]` from a const (which is useless)

Fixes https://github.com/danlehmann/bitfield/issues/66

