### PR TITLE
Support generating field metadata for some runtime introspection

### DIFF
--- a/bitbybit-tests/src/bitfield_tests.rs
+++ b/bitbybit-tests/src/bitfield_tests.rs
@@ -1678,3 +1678,35 @@ fn test_debug_impl() {
     let display_str = format!("{:?}", test);
     assert_eq!(display_str, "Test { upper: 31, lower: 47 }");
 }
+
+#[test]
+fn introspection() {
+    #[bitfield(u32, introspect)]
+    struct Bitfield {
+        #[bits(0..=7)]
+        a: u8,
+        #[bits(8..=15)]
+        b: [u8; 2],
+        #[bits([24..=25, 30..=31])]
+        c: u4,
+        #[bit(29)]
+        d: bool,
+    }
+
+    // <NAME>_BITS exposes the "bits" value(s):
+    assert_eq!(Bitfield::A_BITS, 0..=7);
+    assert_eq!(Bitfield::B_BITS, 8..=15);
+    assert_eq!(Bitfield::C_BITS, [24..=25, 30..=31]);
+    assert_eq!(Bitfield::D_BITS, 29..=29);
+
+    // Arrays also have <NAME>_COUNT and <NAME>_STRIDE
+    assert_eq!(Bitfield::B_COUNT, 2);
+    assert_eq!(Bitfield::B_STRIDE, 8);
+
+    // <name>_mask() returns a mask for the field
+    assert_eq!(Bitfield::a_mask(), 0x000000FF);
+    assert_eq!(Bitfield::b_mask(0), 0x0000FF00);
+    assert_eq!(Bitfield::b_mask(1), 0x00FF0000);
+    assert_eq!(Bitfield::c_mask(), 0xC3000000);
+    assert_eq!(Bitfield::d_mask(), 0x20000000);
+}

--- a/bitbybit-tests/src/bitfield_tests.rs
+++ b/bitbybit-tests/src/bitfield_tests.rs
@@ -1691,6 +1691,8 @@ fn introspection() {
         c: u4,
         #[bit(29)]
         d: bool,
+        #[bit(30)]
+        r#ref: [bool; 2],
     }
 
     // <NAME>_BITS exposes the "bits" value(s):
@@ -1698,10 +1700,13 @@ fn introspection() {
     assert_eq!(Bitfield::B_BITS, 8..=15);
     assert_eq!(Bitfield::C_BITS, [24..=25, 30..=31]);
     assert_eq!(Bitfield::D_BITS, 29..=29);
+    assert_eq!(Bitfield::REF_BITS, 30..=30);
 
     // Arrays also have <NAME>_COUNT and <NAME>_STRIDE
     assert_eq!(Bitfield::B_COUNT, 2);
     assert_eq!(Bitfield::B_STRIDE, 8);
+    assert_eq!(Bitfield::REF_COUNT, 2);
+    assert_eq!(Bitfield::REF_STRIDE, 1);
 
     // <name>_mask() returns a mask for the field
     assert_eq!(Bitfield::a_mask(), 0x000000FF);
@@ -1709,4 +1714,6 @@ fn introspection() {
     assert_eq!(Bitfield::b_mask(1), 0x00FF0000);
     assert_eq!(Bitfield::c_mask(), 0xC3000000);
     assert_eq!(Bitfield::d_mask(), 0x20000000);
+    assert_eq!(Bitfield::ref_mask(0), 0x40000000);
+    assert_eq!(Bitfield::ref_mask(1), 0x80000000);
 }

--- a/bitbybit/CHANGELOG.md
+++ b/bitbybit/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## bitbybit 1.4.0
 
+### Added
+
+- `*_mask()`, as well as `*_BITS`, `*_COUNT`, and `*_STRIDE` constants for fields that provide some information on a
+  field's structure. Enable with the `introspect` attribute on a struct, or globally with the `introspect` feature.
+
 ### Fixed
 
 - Allow qualified paths for `arbitrary_int` fields as well es (optional) `bitenum` fields.

--- a/bitbybit/Cargo.toml
+++ b/bitbybit/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["embedded", "no-std", "data-structures"]
 proc-macro = true
 
 [features]
+introspect = []
 
 [dependencies]
 syn = { version = "2.0", features = ["full"] }

--- a/bitbybit/README.md
+++ b/bitbybit/README.md
@@ -210,6 +210,43 @@ struct GICD_TYPER {
 }
 ```
 
+## Introspection
+
+If information like bit offsets or mask values are needed at runtime, use the `introspect` specifier:
+
+```rs
+    #[bitfield(u32, introspect)]
+    struct Bitfield {
+        #[bits(0..=7)]
+        a: u8,
+        #[bits(8..=15)]
+        b: [u8; 2],
+        #[bits([24..=25, 30..=31])]
+        c: u4,
+        #[bit(29)]
+        d: bool,
+    }
+
+    // <NAME>_BITS exposes the "bits" value(s):
+    assert_eq!(Bitfield::A_BITS, 0..=7);
+    assert_eq!(Bitfield::B_BITS, 8..=15);
+    assert_eq!(Bitfield::C_BITS, [24..=25, 30..=31]);
+    assert_eq!(Bitfield::D_BITS, 29..=29);
+
+    // Arrays also have <NAME>_COUNT and <NAME>_STRIDE
+    assert_eq!(Bitfield::B_COUNT, 2);
+    assert_eq!(Bitfield::B_STRIDE, 8);
+
+    // <name>_mask() returns a mask for the field
+    assert_eq!(Bitfield::a_mask(), 0x000000FF);
+    assert_eq!(Bitfield::b_mask(0), 0x0000FF00);
+    assert_eq!(Bitfield::b_mask(1), 0x00FF0000);
+    assert_eq!(Bitfield::c_mask(), 0xC3000000);
+    assert_eq!(Bitfield::d_mask(), 0x20000000);
+```
+
+This functionality can be enabled for all bitfields by enabling the `introspect` feature.
+
 ## Dependencies
 
 Arbitrary bit widths like u5 or u67 do not exist in Rust at the moment. Therefore, the following dependency is required:

--- a/bitbybit/src/bitfield/codegen.rs
+++ b/bitbybit/src/bitfield/codegen.rs
@@ -1,5 +1,6 @@
 use crate::bitfield::{
-    setter_name, with_name, BaseDataSize, CustomType, FieldDefinition, BITCOUNT_BOOL,
+    const_name, mask_name, setter_name, with_name, BaseDataSize, CustomType, FieldDefinition,
+    BITCOUNT_BOOL,
 };
 use proc_macro2::{Ident, TokenStream as TokenStream2, TokenStream, TokenTree};
 use quote::quote;
@@ -14,10 +15,12 @@ use syn::{LitInt, Type, Visibility};
 /// * `base_data_size` - The size of the bitfield (e.g. u32 for bitfield(u32))
 /// * `internal_base_data_type` - A [`syn::ty::Type`] that represents the same base data type as
 ///   passed in via `base_data_size.internal`. This is a redundant argument to avoid recreating it.
+/// * `introspect` - Whether to generate introspection constants
 pub fn generate(
     field_definitions: &[FieldDefinition],
     base_data_size: BaseDataSize,
     internal_base_data_type: &Type,
+    introspect: bool,
 ) -> Vec<TokenStream> {
     let one = syn::parse_str::<syn::LitInt>(format!("1u{}", base_data_size.internal).as_str())
         .unwrap_or_else(|_| panic!("bitfield!: Error parsing one literal"));
@@ -25,6 +28,60 @@ pub fn generate(
         let total_number_bits = field_definition.ranges.iter().fold(0, |a, b| a + b.len());
         let field_name = &field_definition.field_name;
         let doc_comment = &field_definition.doc_comment;
+
+        let introspect = if introspect {
+            let bits_name = const_name(field_name, "BITS");
+            let ranges_len = field_definition.ranges.len();
+
+            let bits = if ranges_len == 1 {
+                let start = field_definition.ranges[0].start;
+                let end = field_definition.ranges[0].end-1;
+                quote! {
+                    #(#doc_comment)*
+                    const #bits_name: std::ops::RangeInclusive<usize> = #start..=#end;
+                }
+            } else {
+                let range_starts = field_definition.ranges.iter().map(|r| r.start);
+                let range_ends = field_definition.ranges.iter().map(|r| r.end-1);
+                quote! {
+                    #(#doc_comment)*
+                    const #bits_name: [std::ops::RangeInclusive<usize>; #ranges_len] = [#(#range_starts..=#range_ends),*];
+                }
+            };
+
+            let mask_name = mask_name(field_name);
+            let mask = setter_mask(&one, field_definition);
+
+            if let Some((count, stride)) = field_definition.array {
+                let count_name = const_name(field_name, "COUNT");
+                let stride_name = const_name(field_name, "STRIDE");
+                quote! {
+                    #bits
+                    #(#doc_comment)*
+                    const #count_name: usize = #count;
+                    #(#doc_comment)*
+                    const #stride_name: usize = #stride;
+                    #(#doc_comment)*
+                    #[inline]
+                    pub const fn #mask_name(index: usize) -> #internal_base_data_type {
+                        assert!(index < #count);
+                        (#mask) << (index * #stride)
+                    }
+                }
+            } else {
+                quote! {
+                    #bits
+                    #(#doc_comment)*
+                    #[inline]
+                    pub const fn #mask_name() -> #internal_base_data_type {
+                        #mask
+                    }
+                }
+            }
+        } else {
+            quote! {}
+        };
+
         let getter =
             if let Some(getter_type) = field_definition.getter_type.as_ref() {
                 // Main work: Shift and mask the bits into extracted_bits
@@ -135,6 +192,7 @@ pub fn generate(
         };
 
         quote! {
+            #introspect
             #getter
             #setter
         }

--- a/bitbybit/src/bitfield/codegen.rs
+++ b/bitbybit/src/bitfield/codegen.rs
@@ -38,14 +38,14 @@ pub fn generate(
                 let end = field_definition.ranges[0].end-1;
                 quote! {
                     #(#doc_comment)*
-                    const #bits_name: std::ops::RangeInclusive<usize> = #start..=#end;
+                    const #bits_name: core::ops::RangeInclusive<usize> = #start..=#end;
                 }
             } else {
                 let range_starts = field_definition.ranges.iter().map(|r| r.start);
                 let range_ends = field_definition.ranges.iter().map(|r| r.end-1);
                 quote! {
                     #(#doc_comment)*
-                    const #bits_name: [std::ops::RangeInclusive<usize>; #ranges_len] = [#(#range_starts..=#range_ends),*];
+                    const #bits_name: [core::ops::RangeInclusive<usize>; #ranges_len] = [#(#range_starts..=#range_ends),*];
                 }
             };
 

--- a/bitbybit/src/bitfield/mod.rs
+++ b/bitbybit/src/bitfield/mod.rs
@@ -141,7 +141,7 @@ impl BitfieldAttributes {
 pub fn bitfield(args: TokenStream, input: TokenStream) -> TokenStream {
     let mut bitfield_attrs = BitfieldAttributes::default();
     if cfg!(feature = "introspect") {
-        bitfield_attrs.introspect = true
+        bitfield_attrs.introspect = true;
     }
     let mut index = 0;
     let bitfield_parser = syn::meta::parser(|meta| {

--- a/bitbybit/src/bitfield/mod.rs
+++ b/bitbybit/src/bitfield/mod.rs
@@ -95,6 +95,7 @@ struct BitfieldAttributes {
     pub base_type: Option<Ident>,
     pub default_val: Option<DefaultVal>,
     pub debug_trait: bool,
+    pub introspect: bool,
 }
 
 impl BitfieldAttributes {
@@ -129,12 +130,19 @@ impl BitfieldAttributes {
             self.debug_trait = true;
             return Ok(());
         }
+        if meta.path.is_ident("introspect") {
+            self.introspect = true;
+            return Ok(());
+        }
         Ok(())
     }
 }
 
 pub fn bitfield(args: TokenStream, input: TokenStream) -> TokenStream {
     let mut bitfield_attrs = BitfieldAttributes::default();
+    if cfg!(feature = "introspect") {
+        bitfield_attrs.introspect = true
+    }
     let mut index = 0;
     let bitfield_parser = syn::meta::parser(|meta| {
         let result = bitfield_attrs.parse(meta, index);
@@ -189,7 +197,12 @@ pub fn bitfield(args: TokenStream, input: TokenStream) -> TokenStream {
         Ok(definitions) => definitions,
         Err(token_stream) => return token_stream.into_compile_error().into(),
     };
-    let accessors = codegen::generate(&field_definitions, base_data_size, &internal_base_data_type);
+    let accessors = codegen::generate(
+        &field_definitions,
+        base_data_size,
+        &internal_base_data_type,
+        bitfield_attrs.introspect,
+    );
 
     let (default_constructor, default_trait) = if let Some(default_value) =
         &bitfield_attrs.default_val
@@ -357,6 +370,40 @@ fn setter_name(field_name: &Ident) -> Ident {
 
     syn::parse_str::<Ident>(format!("set_{}", field_name_without_prefix).as_str())
         .unwrap_or_else(|_| panic!("bitfield!: Error creating setter name"))
+}
+
+fn mask_name(field_name: &Ident) -> Ident {
+    // The field might have started with r#. If so, it was likely used for a keyword. This can be dropped here
+    let field_name_without_prefix = {
+        let s = field_name.to_string();
+        if let Some(s) = s.strip_prefix("r#") {
+            s.to_string()
+        } else {
+            s
+        }
+    };
+
+    syn::parse_str::<Ident>(&format!("{field_name_without_prefix}_mask"))
+        .unwrap_or_else(|_| panic!("bitfield!: Error creating mask name"))
+}
+
+fn const_name(field_name: &Ident, suffix: &str) -> Ident {
+    // The field might have started with r#. If so, it was likely used for a keyword. This can be dropped here
+    let field_name_without_prefix = {
+        let s = field_name.to_string();
+        if let Some(s) = s.strip_prefix("r#") {
+            s.to_string()
+        } else {
+            s
+        }
+    };
+
+    let name = format!("{field_name_without_prefix}_{suffix}")
+        .to_uppercase()
+        .to_string();
+
+    syn::parse_str::<Ident>(&name)
+        .unwrap_or_else(|_| panic!("bitfield!: Error creating {name} name"))
 }
 
 struct FieldDefinition {


### PR DESCRIPTION
resolves #79 

Here's what it looks like:

```rs
#[bitfield(u32, introspect)]
struct Bitfield {
    #[bits(0..=7)]
    a: u8,
    #[bits(8..=15)]
    b: [u8; 2],
    #[bits([24..=25, 30..=31])]
    c: u4,
    #[bit(29)]
    d: bool,
}

// <NAME>_BITS exposes the "bits" value(s):
assert_eq!(Bitfield::A_BITS, 0..=7);
assert_eq!(Bitfield::B_BITS, 8..=15);
assert_eq!(Bitfield::C_BITS, [24..=25, 30..=31]);
assert_eq!(Bitfield::D_BITS, 29..=29);

// Arrays also have <NAME>_COUNT and <NAME>_STRIDE
assert_eq!(Bitfield::B_COUNT, 2);
assert_eq!(Bitfield::B_STRIDE, 8);

// <name>_mask() returns a mask for the field
assert_eq!(Bitfield::a_mask(), 0x000000FF);
assert_eq!(Bitfield::b_mask(0), 0x0000FF00);
assert_eq!(Bitfield::b_mask(1), 0x00FF0000);
assert_eq!(Bitfield::c_mask(), 0xC3000000);
assert_eq!(Bitfield::d_mask(), 0x20000000);
```

A couple design decisions that may be worth discussing:

* `*_BITS` is a single range for contiguous bitfields, and a slice of ranges for non-contiguous ones. It could be simpler to always generate a slice (eg. `A_BITS == [0..=7]`), but since most fields are contiguous and the single range is much more ergonomic in that case, I went with that. I'm a bit on the fence about that decision though.
* `*_mask()` is a const method, so that we can accomodate arrays. The main alternatives would be:
  * Have a single mask constant, and the user can shift based on `*_COUNT` and `*_STRIDE`. That would work, but since we've already generated 90% of the work, may as well give them a function.
  * Generate mask as a slice (eg `const B_MASK = [0xFF00, [0xFF0000]`). That could be a lot of constants for large arrays though.
* These values can be enabled per-struct with an attribute, or globally with a feature. Having it as a feature allows users to turn it on by default, and also to get introspection data from external defintions that may not have included the attribute.
* I'm open to changing the `introspect` name, as I think introspection implies a bit more than what we're generating here. Not really sure what else to go with though.