### PR TITLE
Add support for signed arbitrary-ints

### DIFF
--- a/bitbybit-tests/Cargo.toml
+++ b/bitbybit-tests/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 
 [dependencies]
 bitbybit = { path = "../bitbybit" }
-arbitrary-int = "1.3"
+arbitrary-int = "2.0"
 defmt = "1"
 
 [features]

--- a/bitbybit/CHANGELOG.md
+++ b/bitbybit/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## bitbybit 2.0.0
+
+This version expects arbitrary-int 2.x.
+
+### Added
+
+- Support for signed arbitrary-int integers as field types, e.g. `i3`, `i24`, etc.
+
 ## bitbybit 1.4.0
 
 This is the final version to support arbitrary-int 1.x. Future versions will require arbitrary-int 2.x.

--- a/bitbybit/Cargo.toml
+++ b/bitbybit/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bitbybit"
-version = "1.4.0"
+version = "2.0.0"
 authors = ["Daniel Lehmann <danlehmannmuc@gmail.com>"]
 edition = "2021"
 description = "Efficient implementation of bit-fields where several numbers are packed within a larger number and bit-enums. Useful for drivers, so it works in no_std environments"
@@ -23,7 +23,7 @@ examples = ["arbitrary-int/defmt"]
 syn = { version = "2.0", features = ["full"] }
 quote = "1.0"
 proc-macro2 = "1.0"
-arbitrary-int = "1.3.0"
+arbitrary-int = "2.0"
 
 [dev-dependencies]
 defmt = "1"

--- a/bitbybit/README.md
+++ b/bitbybit/README.md
@@ -284,10 +284,11 @@ struct GICD_TYPER {
 
 ## Dependencies
 
-Arbitrary bit widths like u5 or u67 do not exist in Rust at the moment. Therefore, the following dependency is required:
+Arbitrary bit widths like u5, u67 or i81 do not exist in Rust at the moment. Therefore, the following dependency is
+required:
 
 ```toml
-arbitrary-int = "1.3.0"
+arbitrary-int = "2.0"
 ```
 
 ## Usage


### PR DESCRIPTION
They work mostly like unsigned ints.

To construct, they provide the same extract_u32 (and similar methods), which
work just fine. To deconstruct however, we can't call `.value()` as that's a
signed (and sign-extended) value. Instead, they provide the new `.to_bits()`
function which does what we want.

Fixes #72
