### PR TITLE
convert arbitrary-int to dev dependency

### DIFF
--- a/bitbybit/Cargo.toml
+++ b/bitbybit/Cargo.toml
@@ -23,8 +23,8 @@ examples = ["arbitrary-int/defmt"]
 syn = { version = "2.0", features = ["full"] }
 quote = "1.0"
 proc-macro2 = "1.0"
-arbitrary-int = "2.0"
 
 [dev-dependencies]
 defmt = "1"
 trybuild = "1"
+arbitrary-int = "2"


### PR DESCRIPTION
I was looking into updating some dependencies and was considering possible compatibility issues between bitbybit and arbitrary-int.

I saw that there is a dependency, but that dependency can be a dev-dependency without breaking anything (at least not the existing tests).