### PR TITLE
Improve defmt codegen

### DIFF
--- a/bitbybit/CHANGELOG.md
+++ b/bitbybit/CHANGELOG.md
@@ -8,6 +8,11 @@ This version expects arbitrary-int 2.x.
 
 - Support for signed arbitrary-int integers as field types, e.g. `i3`, `i24`, etc.
 
+### Fixed
+
+- Use fully qualified trait syntax in `defmt_bitfields` macro implementation, avoiding the need
+  for users to import the `arbitrary_int::traits::Integer` trait for auto-generated code.
+
 ## bitbybit 1.4.0
 
 This is the final version to support arbitrary-int 1.x. Future versions will require arbitrary-int 2.x.

--- a/bitbybit/src/bitfield/codegen.rs
+++ b/bitbybit/src/bitfield/codegen.rs
@@ -609,10 +609,18 @@ pub fn generate_defmt_trait_impl(
                             quote! { self.raw_value() }
                         }
                         _ => match base_data_size.internal {
-                            0..=7 => quote! { self.raw_value().as_u8() },
-                            8..=15 => quote! { self.raw_value().as_u16() },
-                            16..=31 => quote! { self.raw_value().as_u32() },
-                            32..=63 => quote! { self.raw_value().as_u64() },
+                            0..=7 => {
+                                quote! { arbitrary_int::traits::Integer::as_u8(self.raw_value()) }
+                            }
+                            8..=15 => {
+                                quote! { arbitrary_int::traits::Integer::as_u16(self.raw_value()) }
+                            }
+                            16..=31 => {
+                                quote! { arbitrary_int::traits::Integer::as_u32(self.raw_value()) }
+                            }
+                            32..=63 => {
+                                quote! { arbitrary_int::traits::Integer::as_u64(self.raw_value()) }
+                            }
                             _ => panic!("Unsupported base data size for defmt_bitfields"),
                         },
                     }

--- a/qemu-tests/Cargo.toml
+++ b/qemu-tests/Cargo.toml
@@ -12,7 +12,7 @@ cortex-m-semihosting = "0.5.0"
 defmt = "1"
 defmt-semihosting = "0.3"
 bitbybit = { path = "../bitbybit" }
-arbitrary-int = { version = "1.3", features = ["defmt"] }
+arbitrary-int = { version = "2", features = ["defmt"] }
 
 [profile.dev]
 opt-level = 1


### PR DESCRIPTION
Use fully qualified trait syntax in `defmt_bitfields` macro implementation, avoiding the need
 for users to import the `arbitrary_int::traits::Integer` trait for auto-generated code.