### PR TITLE
Make introspect constants public

### DIFF
--- a/bitbybit-tests/src/bitfield_tests.rs
+++ b/bitbybit-tests/src/bitfield_tests.rs
@@ -1820,19 +1820,24 @@ fn test_debug_impl() {
 
 #[test]
 fn introspection() {
-    #[bitfield(u32, introspect)]
-    struct Bitfield {
-        #[bits(0..=7)]
-        a: u8,
-        #[bits(8..=15)]
-        b: [u8; 2],
-        #[bits([24..=25, 30..=31])]
-        c: u4,
-        #[bit(29)]
-        d: bool,
-        #[bit(30)]
-        r#ref: [bool; 2],
+    // Put into module to ensure everything's pub
+    mod test {
+        #[bitbybit::bitfield(u32, introspect)]
+        pub struct Bitfield {
+            #[bits(0..=7)]
+            a: u8,
+            #[bits(8..=15)]
+            b: [u8; 2],
+            #[bits([24..=25, 30..=31])]
+            c: u4,
+            #[bit(29)]
+            d: bool,
+            #[bit(30)]
+            r#ref: [bool; 2],
+        }
     }
+
+    use test::Bitfield;
 
     // <NAME>_BITS exposes the "bits" value(s):
     assert_eq!(Bitfield::A_BITS, 0..=7);

--- a/bitbybit/src/bitfield/codegen.rs
+++ b/bitbybit/src/bitfield/codegen.rs
@@ -38,14 +38,14 @@ pub fn generate(
                 let end = field_definition.ranges[0].end-1;
                 quote! {
                     #(#doc_comment)*
-                    const #bits_name: core::ops::RangeInclusive<usize> = #start..=#end;
+                    pub const #bits_name: core::ops::RangeInclusive<usize> = #start..=#end;
                 }
             } else {
                 let range_starts = field_definition.ranges.iter().map(|r| r.start);
                 let range_ends = field_definition.ranges.iter().map(|r| r.end-1);
                 quote! {
                     #(#doc_comment)*
-                    const #bits_name: [core::ops::RangeInclusive<usize>; #ranges_len] = [#(#range_starts..=#range_ends),*];
+                    pub const #bits_name: [core::ops::RangeInclusive<usize>; #ranges_len] = [#(#range_starts..=#range_ends),*];
                 }
             };
 
@@ -58,9 +58,9 @@ pub fn generate(
                 quote! {
                     #bits
                     #(#doc_comment)*
-                    const #count_name: usize = #count;
+                    pub const #count_name: usize = #count;
                     #(#doc_comment)*
-                    const #stride_name: usize = #stride;
+                    pub const #stride_name: usize = #stride;
                     #(#doc_comment)*
                     #[inline]
                     pub const fn #mask_name(index: usize) -> #internal_base_data_type {


### PR DESCRIPTION
These were private, which isn't all that useful.

Fixes: 89