### PR TITLE
fix for nightly clippy

### DIFF
--- a/.github/workflows/test-debug.yml
+++ b/.github/workflows/test-debug.yml
@@ -29,6 +29,14 @@ jobs:
       # the .cargo/config.toml file inside the QEMU test folder.
       - run: cd qemu-tests && cargo build --target thumbv7em-none-eabihf
 
+  clippy-output:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo clippy --examples
+
   # Run some programs in QEMU 9
   qemu-test:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Nightly clippy complains about double parenthesis (https://rust-lang.github.io/rust-clippy/master/index.html#double_parens).

After looking at some expansions, I think the double parenthesis comes from the getter methods. I also added a clippy check to the CI, but that check is only on stable.. I could add it for nightly as well, I added basic coverage for stable first.